### PR TITLE
Distributed Maintenance Mode

### DIFF
--- a/app/Console/Commands/DownCommand.php
+++ b/app/Console/Commands/DownCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Cache;
+use \Illuminate\Foundation\Console\DownCommand as Down;
+
+class DownCommand extends Down
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'down {--redirect= : The path that users should be redirected to}
+                                 {--render= : The view that should be prerendered for display during maintenance mode}
+                                 {--retry= : The number of seconds after which the request may be retried}
+                                 {--secret= : The secret phrase that may be used to bypass maintenance mode}
+                                 {--status=503 : The status code that should be used when returning the maintenance mode response}
+                                 {--message=We\'ll be right back. : A message to display on the maintenance page}';
+
+
+    /**
+     * Execute the console command.
+     *
+     * Overrides Laravel's DownCommand to use the cache instead of the
+     * filesystem so that maintenance mode is propagated across all
+     * servers and job queues.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        Cache::forever(config('app.maintenance_key'), json_encode($this->getDownFilePayload()));
+        $this->comment('Application is now in maintenance mode.');
+    }
+
+    /**
+     * Get the payload to be placed in the "down" file.
+     *
+     * @return array
+     */
+    protected function getDownFilePayload()
+    {
+        return [
+            'redirect' => $this->redirectPath(),
+            'retry' => $this->getRetryTime(),
+            'secret' => $this->option('secret'),
+            'status' => (int) $this->option('status', 503),
+            'template' => $this->option('render') ? $this->prerenderView() : null,
+            'message' => $this->option('message'),
+        ];
+    }
+}

--- a/app/Console/Commands/UpCommand.php
+++ b/app/Console/Commands/UpCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Cache;
+use \Illuminate\Foundation\Console\UpCommand as Up;
+
+class UpCommand extends Up
+{
+    /**
+     * Execute the console command.
+     *
+     * Overrides Laravel's UpCommand to use the cache instead of the
+     * filesystem so that maintenance mode is propagated across all
+     * servers and job queues.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        Cache::forget(config('app.maintenance_key'));
+        $this->info('Application is now live.');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,8 @@
 
 namespace App\Console;
 
+use App\Console\Commands\DownCommand;
+use App\Console\Commands\UpCommand;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -13,7 +15,8 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        //
+        DownCommand::class,
+        UpCommand::class,
     ];
 
     /**

--- a/app/Extensions/Illuminate/Foundation/Application.php
+++ b/app/Extensions/Illuminate/Foundation/Application.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace App\Extensions\Illuminate\Foundation;
+
+use Cache;
+use \Illuminate\Foundation\Application as App;
+
+class Application extends App
+{
+    /**
+     * Returns whether the application is down for maintenance.
+     *
+     * Laravel maintenance mode is overridden to use the cache instead of the filesystem,
+     * allowing us to treat Redis as a global distributed lock so that
+     * maintenance mode is propagated to multiple servers.
+     *
+     * @return bool Whether the app is in maintenance mod.
+     */
+    public function isDownForMaintenance()
+    {
+        return Cache::has(config('app.maintenance_key'));
+    }
+}

--- a/app/Http/Middleware/CheckForMaintenanceMode.php
+++ b/app/Http/Middleware/CheckForMaintenanceMode.php
@@ -2,7 +2,11 @@
 
 namespace App\Http\Middleware;
 
+use Cache;
+use Closure;
+use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
 use Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode as Middleware;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class CheckForMaintenanceMode extends Middleware
 {
@@ -14,4 +18,58 @@ class CheckForMaintenanceMode extends Middleware
     protected $except = [
         //
     ];
+
+    /**
+     * Handle an incoming request.
+     *
+     * If the application is in maintenance mode, we retrieve the payload from the cache containing
+     * the user set message and time to display on the error page when the MaintenanceModeException
+     * is thrown.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if ($this->app->isDownForMaintenance()) {
+            $data = json_decode(Cache::get(config('app.maintenance_key')), true);
+
+            if (isset($data['secret']) && $request->path() === $data['secret']) {
+                return $this->bypassResponse($data['secret']);
+            }
+
+            if ($this->hasValidBypassCookie($request, $data) ||
+                $this->inExceptArray($request)) {
+                return $next($request);
+            }
+
+            if (isset($data['redirect'])) {
+                $path = $data['redirect'] === '/'
+                    ? $data['redirect']
+                    : trim($data['redirect'], '/');
+
+                if ($request->path() !== $path) {
+                    return redirect($path);
+                }
+            }
+
+            if (isset($data['template'])) {
+                return response(
+                    $data['template'],
+                    $data['status'] ?? 503,
+                    isset($data['retry']) ? ['Retry-After' => $data['retry']] : []
+                );
+            }
+
+            throw new HttpException(
+                $data['status'] ?? 503,
+                $data['message'],
+                null,
+                isset($data['retry']) ? ['Retry-After' => $data['retry']] : []
+            );
+        }
+
+        return $next($request);
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use App\CalendarEvent;
+use App\Console\Commands\DownCommand;
+use App\Console\Commands\UpCommand;
 use App\Observers\CalendarEventObserver;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\URL;
@@ -30,6 +32,23 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        /**
+         * Override Laravel's "php artisan down" command to put the application in maintenance mode
+         * using our custom Redis based lock.
+         */
+        $this->app->extend('command.down', function () {
+            return new DownCommand();
+        });
+
+        /**
+         * Override Laravel's "php artisan up" command to bring the application out of maintenance mode
+         * using our custom Redis based lock.
+         */
+        $this->app->extend('command.up', function () {
+            return new UpCommand();
+        });
+
+
         // URL::forceRootUrl(config('app.url'));
         Paginator::useBootstrap();
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,7 @@
 |
 */
 
-$app = new Illuminate\Foundation\Application(
+$app = new App\Extensions\Illuminate\Foundation\Application(
     $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__)
 );
 

--- a/config/app.php
+++ b/config/app.php
@@ -27,6 +27,7 @@ return [
     */
 
     'env' => env('APP_ENV', 'production'),
+    'maintenance_key' => 'maintenance-mode-payload',
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/js/calendar/calendar_inputs_edit.js
+++ b/resources/js/calendar/calendar_inputs_edit.js
@@ -5127,11 +5127,12 @@ function calendar_saved(){
 }
 
 function calendar_save_failed(){
+    var text = "Failed to save!"
 
-	var text = "Failed to save!"
-
-	save_button.prop('disabled', true).toggleClass('btn-secondary', false).toggleClass('btn-success', true).toggleClass('btn-primary', false).toggleClass('btn-warning', true).toggleClass('btn-danger', false).text(text);
-
+    save_button.prop('disabled', true).toggleClass(['btn-secondary', 'btn-primary', 'btn-danger'], false).toggleClass(['btn-success', 'btn-warning'], true).text(text);
+    setInterval(function(){
+        evaluate_save_button(true);
+    }, 10000);
 }
 
 function evaluate_save_button(override){

--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -1,0 +1,33 @@
+@extends('templates._page')
+
+@push('head')
+    <style>
+        @import url('https://fonts.googleapis.com/css?family=Cabin+Sketch');
+
+
+        h1 {
+            font-size: 3em;
+            text-align: center;
+            opacity: .8;
+            order: 1;
+        }
+
+        h1, h2 {
+            font-family: 'Cabin Sketch', cursive;
+        }
+
+        #content {
+            height: 100%;
+            display: grid;
+            place-items: center;
+            text-align: center;
+        }
+    </style>
+@endpush
+
+@section('content')
+    <div class="container">
+        <h1>Fantasy Calendar is down for maintenance.</h1>
+        <h2>{{ json_decode(Cache::get(config('app.maintenance_key')), true)['message'] ?? "We'll be right back." }}</h2>
+    </div>
+@endsection

--- a/resources/views/templates/_head_content.blade.php
+++ b/resources/views/templates/_head_content.blade.php
@@ -98,6 +98,15 @@
             return;
         }
 
+        if(jqxhr.status === 503) {
+            if(jqxhr.responseJSON.message.length > 0) {
+                $.notify("Fantasy Calendar is in maintenance mode. Please try again later.\nReason: " + jqxhr.responseJSON.message);
+            } else {
+                $.notify("Fantasy Calendar is in maintenance mode. Please try that again later.");
+            }
+            return;
+        }
+
         $.notify(thrownError + " (F12 to see more detail)");
     });
 

--- a/setup/lambda/dev/forwarder.js
+++ b/setup/lambda/dev/forwarder.js
@@ -6,7 +6,7 @@ exports.handler = (event, context, callback) => {
 
     headers['x-forwarded-host'] = [ {
         key: 'X-Forwarded-Host',
-        value: 'lambda-dev.fantasy-calendar.com'
+        value: 'beta.fantasy-calendar.com'
     }];
 
     callback(null, request);


### PR DESCRIPTION
This introduces extensions to the `artisan down` and `artisan up` commands and the core application, adjusting maintenance mode to rely on cache instead of the filesystem. 

The main goal is to support maintenance mode while running on distributed systems (such as Lambda, or our Docker cluster).

It also creates a custom 503 page that displays a custom maintenance mode message:  

![Selection_943](https://user-images.githubusercontent.com/2779682/96954431-61fac480-14c1-11eb-93a4-100961416ec7.png)


 as well as custom notifications to users when an error is caused by maintenance mode:

![Selection_944](https://user-images.githubusercontent.com/2779682/96954519-89ea2800-14c1-11eb-8be0-caab3d6dae0d.png)

---

It seems pretty rock-solid, think it's ready to merge.