### PR TITLE
Relabel Confusing Save Button

### DIFF
--- a/public/changelog.md
+++ b/public/changelog.md
@@ -1,3 +1,6 @@
+### 2.X.X - Adjective Efreet
+* Tweaked - Renamed the "Create Calendar" button to "Save Calendar" to avoid confusion
+
 ### 2.0.20 - Typesetting Efreet
 #### May 15, 2021
 * Tweaked - Default era formatting tweaked to utilize era year instead of absolute year when era restarts the year count 

--- a/resources/js/calendar/calendar_inputs_edit.js
+++ b/resources/js/calendar/calendar_inputs_edit.js
@@ -5538,7 +5538,7 @@ function evaluate_save_button(override){
 
 		var invalid = errors.length > 0;
 
-		var text = invalid ? "Cannot create yet" : "Create calendar";
+		var text = invalid ? "Cannot create yet" : "Save Calendar";
 
 		var apply_changes_immediately = $('#apply_changes_immediately').is(':checked');
 


### PR DESCRIPTION
We're renaming the "Create Calendar" button to "Save Calendar" because it's apparently confusing. =]
