### PR TITLE
Remove 2.0 Announcement

### DIFF
--- a/resources/views/calendar/list.blade.php
+++ b/resources/views/calendar/list.blade.php
@@ -47,10 +47,6 @@
             <div class="alert alert-warning py-3">{{ session('alert-warning') }}</div>
         @endif
 
-        @if(!auth()->user()->acknowledged_migration)
-            <div class="alert alert-info"><a href="{{ route('account-migrated-acknowledge') }}" class="alert-link" style="float: right;"><i class="fa fa-times"></i></a> <strong>Welcome to Fantasy Calendar 2.0!</strong> A lot has changed. <br><br>You <a class="alert-link" href="{{ route('whats-new') }}">check out what's new</a> to see a quick overview, or click a calendar below to see for yourself!</div>
-        @endif
-
         @if(!auth()->user()->acknowledged_discord_announcement)
             <div class="alert alert-info"><a href="{{ route('discord-announcement-acknowledge') }}" class="alert-link" style="float: right;"><i class="fa fa-times"></i></a>
                 <h4><i class="fab fa-discord"></i> <strong>Fantasy-Calendar's Discord Integration</strong> has just landed!</h4>


### PR DESCRIPTION
This PR will remove the "Welcome to Fantasy Calendar 2.0!" messaging at the top of the app.

It's been a year almost, if they haven't seen the announcement yet they ain't gonna. :slight_smile:
