### PR TITLE
App Feature Flags

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -3,6 +3,7 @@
 namespace App\Http;
 
 use App\Http\Middleware\CheckAccountDeletionRequested;
+use App\Http\Middleware\EnsureFeatureIsEnabled;
 use App\Http\Middleware\RequirePremium;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 
@@ -74,6 +75,7 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'premium' => RequirePremium::class,
+        'feature' => EnsureFeatureIsEnabled::class,
     ];
 
     /**

--- a/app/Http/Middleware/EnsureFeatureIsEnabled.php
+++ b/app/Http/Middleware/EnsureFeatureIsEnabled.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class EnsureFeatureIsEnabled
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     */
+    public function handle(Request $request, Closure $next, string $featureName)
+    {
+        if(!feature($featureName)) {
+            abort(404);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -227,7 +227,12 @@ class User extends Authenticatable implements
         return $this;
     }
 
+    // If Stripe is not enabled as a feature, we just want all the premium things available.
     public function isPremium() {
+        if(!feature('stripe')) {
+            return true;
+        }
+
         return $this->paymentLevel() !== 'Free';
     }
 

--- a/app/Policies/CalendarPolicy.php
+++ b/app/Policies/CalendarPolicy.php
@@ -64,6 +64,11 @@ class CalendarPolicy
         return true;
     }
 
+    public function embedAny(?User $user)
+    {
+        return feature('embed');
+    }
+
     /**
      * Determine whether the user can update the calendar.
      *

--- a/app/Policies/PersonalAccessTokenPolicy.php
+++ b/app/Policies/PersonalAccessTokenPolicy.php
@@ -21,7 +21,6 @@ class PersonalAccessTokenPolicy
 
     public function interact(?User $user)
     {
-        return false;
-        return $user->isPremium();
+        return feature('apitokens') && $user->isPremium();
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -66,6 +66,10 @@ class AppServiceProvider extends ServiceProvider
             return auth()->check() && auth()->user()->setting($value);
         });
 
+        Blade::if('feature', function($value) {
+            return feature($value);
+        });
+
         if(app()->environment(['local'])) {
             URL::forceRootUrl(config('app.url'));
         }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -354,6 +354,10 @@ if(!function_exists('mdToHtml')) {
 
 if(!function_exists('feature')) {
     function feature($name) {
+        if(empty(config('app.features_enabled'))) {
+            return true;
+        }
+
         return in_array($name, config('app.features_enabled'));
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -351,3 +351,9 @@ if(!function_exists('mdToHtml')) {
         return (new League\CommonMark\GithubFlavoredMarkdownConverter())->convert($markdown);
     }
 }
+
+if(!function_exists('feature')) {
+    function feature($name) {
+        return in_array($name, config('app.features_enabled'));
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -67,6 +67,8 @@ return [
 
     'mix_url' => env('MIX_ASSET_URL', null),
 
+    'features_enabled' => explode(',', env('APP_FEATURES_ENABLED')),
+
     /*
     |--------------------------------------------------------------------------
     | Application Timezone

--- a/config/app.php
+++ b/config/app.php
@@ -67,7 +67,7 @@ return [
 
     'mix_url' => env('MIX_ASSET_URL', null),
 
-    'features_enabled' => explode(',', env('APP_FEATURES_ENABLED')),
+    'features_enabled' => env('APP_FEATURES_ENABLED', null) ? explode(',', env('APP_FEATURES_ENABLED')) : '',
 
     /*
     |--------------------------------------------------------------------------

--- a/config/services.php
+++ b/config/services.php
@@ -36,7 +36,7 @@ return [
     ],
 
     'discord' => [
-        'enabled' => (!empty(env('DISCORD_CLIENT_ID')) && !empty(env('DISCORD_CLIENT_SECRET')) && !empty(env('DISCORD_REDIRECT_URI'))),
+        'enabled' => feature('discord'),
         'client_id' => env('DISCORD_CLIENT_ID'),
         'client_secret' => env('DISCORD_CLIENT_SECRET'),
         'redirect' => env('DISCORD_REDIRECT_URI'),

--- a/resources/views/calendar/list.blade.php
+++ b/resources/views/calendar/list.blade.php
@@ -304,9 +304,11 @@
                                         </span>
                                     </div>
                                     <div class="py-1" role="none">
+                                        @feature('embed')
                                         <a class="text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 block px-4 py-2 text-md" href="{{ route('calendars.guided_embed', ['calendar' => $calendar->hash]) }}" role="menuitem" tabindex="-1">
                                             Embed
                                         </a>
+                                        @endfeature
                                         <a class="text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 block px-4 py-2 text-md" href="{{ route('calendars.show', ['calendar' => $calendar->hash, 'print' => 1]) }}"  >
                                             Print
                                         </a>

--- a/resources/views/calendar/list.blade.php
+++ b/resources/views/calendar/list.blade.php
@@ -82,29 +82,31 @@
             <x-alert type="warning" class="mb-4">{{ session('alert-warning') }}</x-alert>
         @endif
 
-        @if(!auth()->user()->acknowledged_discord_announcement)
-            <x-alert type="notice"
-                     icon="fab fa-discord"
-                     class="relative mb-4"
-                     x-data="{ show: true }"
-                     x-show="show"
-                     x-transition:enter="transform ease-out duration-300 transition"
-                     x-transition:enter-start="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2"
-                     x-transition:enter-end="translate-y-0 opacity-100 sm:translate-x-0"
-                     x-transition:leave="transition ease-in duration-100"
-                     x-transition:leave-start="opacity-100"
-                     x-transition:leave-end="opacity-0"
-            >
-                <i @click="axios.get('{{ route('discord-announcement-acknowledge') }}').then(() => { show = false; $dispatch('notification', { title: 'Dismissed!', body: `You can always check out the Discord integration via 'integrations' on your profile.` }) })" class="cursor-pointer fa fa-times float-right"></i>
-                <h4 class="font-semibold">Fantasy Calendar integrates with Discord!</h4>
+        @feature('discord')
+            @if(!auth()->user()->acknowledged_discord_announcement)
+                <x-alert type="notice"
+                         icon="fab fa-discord"
+                         class="relative mb-4"
+                         x-data="{ show: true }"
+                         x-show="show"
+                         x-transition:enter="transform ease-out duration-300 transition"
+                         x-transition:enter-start="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2"
+                         x-transition:enter-end="translate-y-0 opacity-100 sm:translate-x-0"
+                         x-transition:leave="transition ease-in duration-100"
+                         x-transition:leave-start="opacity-100"
+                         x-transition:leave-end="opacity-0"
+                >
+                    <i @click="axios.get('{{ route('discord-announcement-acknowledge') }}').then(() => { show = false; $dispatch('notification', { title: 'Dismissed!', body: `You can always check out the Discord integration via 'integrations' on your profile.` }) })" class="cursor-pointer fa fa-times float-right"></i>
+                    <h4 class="font-semibold">Fantasy Calendar integrates with Discord!</h4>
 
-                @if(!auth()->user()->isPremium())
-                    <div>All the information about this subscriber feature (<a class="font-semibold underline hover:text-blue-500 dark:hover:text-white" href="{{ route('subscription.pricing') }}">only $2.49/month!</a>) can be found <a class="font-semibold underline hover:text-blue-500 dark:hover:text-white" href="{{ route('discord') }}">on this page</a>!</div>
-                @else
-                    <div>All the information can be found <a class="font-semibold underline hover:text-blue-500 dark:hover:text-white" href="{{ route('discord') }}">on this page</a> - as a subscriber, you have immediate <a class="font-semibold underline hover:text-blue-500 dark:hover:text-white" href="{{ route('profile.integrations') }}">access</a>!</div>
-                @endif
-            </x-alert>
-        @endif
+                    @if(!auth()->user()->isPremium())
+                        <div>All the information about this subscriber feature (<a class="font-semibold underline hover:text-blue-500 dark:hover:text-white" href="{{ route('subscription.pricing') }}">only $2.49/month!</a>) can be found <a class="font-semibold underline hover:text-blue-500 dark:hover:text-white" href="{{ route('discord') }}">on this page</a>!</div>
+                    @else
+                        <div>All the information can be found <a class="font-semibold underline hover:text-blue-500 dark:hover:text-white" href="{{ route('discord') }}">on this page</a> - as a subscriber, you have immediate <a class="font-semibold underline hover:text-blue-500 dark:hover:text-white" href="{{ route('profile.integrations') }}">access</a>!</div>
+                    @endif
+                </x-alert>
+            @endif
+        @endfeature
 
         @foreach($invitations as $invitation)
             <x-alert type="success" icon="" class="mb-10">

--- a/resources/views/layouts/app-fullwidth.blade.php
+++ b/resources/views/layouts/app-fullwidth.blade.php
@@ -32,7 +32,9 @@
                         <x-nav-link href="{{ route('calendars.index') }}">My Calendars</x-nav-link>
                         <x-nav-link href="{{ route('calendars.create') }}">New Calendar</x-nav-link>
                         <x-nav-link href="{{ route('faq') }}">FAQs</x-nav-link>
-                        <x-nav-link href="{{ route('discord') }}">Discord Integration</x-nav-link>
+                        @feature('discord')
+                            <x-nav-link href="{{ route('discord') }}">Discord Integration</x-nav-link>
+                        @endfeature
                     </div>
                 </div>
                 <div class="hidden sm:ml-6 sm:flex sm:items-center sm:space-x-4">
@@ -52,22 +54,8 @@
                     <!-- Mobile menu button -->
                     <button class="inline-flex items-center justify-center p-2 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white" @click="menu = !menu">
                         <span class="sr-only">Open main menu</span>
-                        <!--
-                          Heroicon name: menu
-
-                          Menu open: "hidden", Menu closed: "block"
-                        -->
-                        <svg class="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                        </svg>
-                        <!--
-                          Heroicon name: x
-
-                          Menu open: "block", Menu closed: "hidden"
-                        -->
-                        <svg class="hidden h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                        </svg>
+                        <x-heroicon-o-menu ::class="{ 'hidden': !menu, 'block': menu }" class="block h-6 w-6"></x-heroicon-o-menu>
+                        <x-heroicon-o-x ::class="{ 'hidden': menu, 'block': !menu }" class="hidden h-6 w-6"></x-heroicon-o-x>
                     </button>
                 </div>
             </div>

--- a/resources/views/layouts/app-guest.blade.php
+++ b/resources/views/layouts/app-guest.blade.php
@@ -20,7 +20,9 @@
                         <x-nav-link href="{{ route('calendars.index') }}">My Calendars</x-nav-link>
                         <x-nav-link href="{{ route('calendars.create') }}">New Calendar</x-nav-link>
                         <x-nav-link href="{{ route('faq') }}">FAQs</x-nav-link>
-                        <x-nav-link href="{{ route('discord') }}">Discord Integration</x-nav-link>
+                        @feature('discord')
+                            <x-nav-link href="{{ route('discord') }}">Discord Integration</x-nav-link>
+                        @endfeature
                     </div>
                 </div>
                 <div class="hidden sm:ml-6 sm:flex sm:items-center sm:space-x-4">
@@ -32,22 +34,8 @@
                     <!-- Mobile menu button -->
                     <button class="inline-flex items-center justify-center p-2 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white" @click="menu = !menu">
                         <span class="sr-only">Open main menu</span>
-                        <!--
-                          Heroicon name: menu
-
-                          Menu open: "hidden", Menu closed: "block"
-                        -->
-                        <svg class="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                        </svg>
-                        <!--
-                          Heroicon name: x
-
-                          Menu open: "block", Menu closed: "hidden"
-                        -->
-                        <svg class="hidden h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                        </svg>
+                        <x-heroicon-o-menu ::class="{ 'hidden': !menu, 'block': menu }" class="block h-6 w-6"></x-heroicon-o-menu>
+                        <x-heroicon-o-x ::class="{ 'hidden': menu, 'block': !menu }" class="hidden h-6 w-6"></x-heroicon-o-x>
                     </button>
                 </div>
             </div>

--- a/resources/views/layouts/profile.blade.php
+++ b/resources/views/layouts/profile.blade.php
@@ -5,7 +5,9 @@
                 <aside class="pb-6 px-2 sm:px-6 lg:pb-0 lg:px-0 lg:col-span-3">
                     <nav class="space-y-1">
                         <x-left-nav-item icon="cog" label="Account" route="profile"></x-left-nav-item>
-                        <x-left-nav-item icon="credit-card" label="Plan & Billing" route="profile.billing"></x-left-nav-item>
+                        @feature('stripe')
+                            <x-left-nav-item icon="credit-card" label="Plan & Billing" route="profile.billing"></x-left-nav-item>
+                        @endfeature
 
                         @feature('discord')
                             <x-left-nav-item icon="puzzle-piece" label="Integrations" route="profile.integrations"></x-left-nav-item>

--- a/resources/views/layouts/profile.blade.php
+++ b/resources/views/layouts/profile.blade.php
@@ -7,9 +7,9 @@
                         <x-left-nav-item icon="cog" label="Account" route="profile"></x-left-nav-item>
                         <x-left-nav-item icon="credit-card" label="Plan & Billing" route="profile.billing"></x-left-nav-item>
 
-                        @if(config('services.discord.enabled'))
+                        @feature('discord')
                             <x-left-nav-item icon="puzzle-piece" label="Integrations" route="profile.integrations"></x-left-nav-item>
-                        @endif
+                        @endfeature
 
                         @can('interact', \Laravel\Sanctum\PersonalAccessToken::class)
                             <div class="border-t dark:border-gray-800"></div>

--- a/resources/views/templates/_head_content_tw.blade.php
+++ b/resources/views/templates/_head_content_tw.blade.php
@@ -47,7 +47,9 @@
     @endif
 
     <script src="{{ mix('/js/app-tw.js') }}" defer></script>
-    <script src="https://js.stripe.com/v3/"></script>
+    @feature('stripe')
+        <script src="https://js.stripe.com/v3/"></script>
+    @endfeature
 
     <script>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -77,7 +77,7 @@ Route::middleware(['account.deletion', 'agreement'])->group(function(){
     Route::group(['as' => 'calendars.', 'prefix' => 'calendars'], function(){
         Route::get('/{calendar}/guided_embed', [CalendarController::class, 'guidedEmbed'])->name('guided_embed')->middleware('can:embedAny,App\Models\Calendar');
         Route::get('/{calendar}/export', [CalendarController::class, 'export'])->name('export');
-        Route::get('/{calendar}.{ext}', [CalendarController::class, 'renderImage'])->name('image');
+        Route::get('/{calendar}.{ext}', [CalendarController::class, 'renderImage'])->name('image')->middleware('feature:imagerenderer');
     });
 
     Route::resource('calendars', CalendarController::class);

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,7 +27,7 @@ use Intervention\Image\Facades\Image;
 |
 */
 
-Route::get('/embed/{calendar}', [EmbedController::class, 'embedCalendar']);
+Route::get('/embed/{calendar}', [EmbedController::class, 'embedCalendar'])->middleware('can:embedAny,App\Models\Calendar');
 
 Route::get('/', [WelcomeController::class, 'welcome'])->name('home');
 Route::view('/welcome', 'welcome')->name('welcome');
@@ -75,7 +75,7 @@ Route::prefix('invite')->group(function(){
 // Calendar management
 Route::middleware(['account.deletion', 'agreement'])->group(function(){
     Route::group(['as' => 'calendars.', 'prefix' => 'calendars'], function(){
-        Route::get('/{calendar}/guided_embed', [CalendarController::class, 'guidedEmbed'])->name('guided_embed');
+        Route::get('/{calendar}/guided_embed', [CalendarController::class, 'guidedEmbed'])->name('guided_embed')->middleware('can:embedAny,App\Models\Calendar');
         Route::get('/{calendar}/export', [CalendarController::class, 'export'])->name('export');
         Route::get('/{calendar}.{ext}', [CalendarController::class, 'renderImage'])->name('image');
     });

--- a/routes/web.php
+++ b/routes/web.php
@@ -97,7 +97,7 @@ Route::middleware('admin')->as('admin.')->prefix('admin')->group(function() {
 Route::get('/pricing', [SubscriptionController::class, 'pricing'])->name('subscription.pricing');
 
 // Subscription management
-Route::prefix('subscription')->as('subscription.')->middleware(['account.deletion', 'agreement'])->group(function(){
+Route::prefix('subscription')->as('subscription.')->middleware(['account.deletion', 'agreement', 'feature:stripe'])->group(function(){
     Route::get('/subscribe/{level}/{interval}', [SubscriptionController::class, 'subscribe'])->name('subscribe');
     Route::post('/subscribe', [SubscriptionController::class, 'createsubscription'])->name('create');
     Route::post('/cancel', [SubscriptionController::class, 'cancel'])->name('cancel');


### PR DESCRIPTION
Currently we have a few different features that we might want to toggle on/off on a site-wide basis for one reason or another (Mostly on, say, personal deployments):
- Paid/premium requirements
- Discord module
- API Tokens/availability

This PR will seek to implement some kind of "app flags" functionality that lets us gate/wall/disable functionality, directly from our swanky Filament admin panel.
