### PR TITLE
Render fixes, and event duration fixes

### DIFF
--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -46,9 +46,9 @@ class UserResource extends Resource
                 Forms\Components\Section::make('Personal Info')->schema([
                     Forms\Components\TextInput::make('username'),
                     Forms\Components\TextInput::make('email'),
-                    Forms\Components\DatePicker::make('email_verified_at')->label('Verified At'),
-                    Forms\Components\DatePicker::make('date_register')->label('Created at')->disabled(),
-                    Forms\Components\DatePicker::make('last_visited')->disabled(),
+                    Forms\Components\DateTimePicker::make('email_verified_at')->label('Verified At'),
+                    Forms\Components\DateTimePicker::make('date_register')->label('Created at')->disabled(),
+                    Forms\Components\DateTimePicker::make('last_visited')->disabled(),
                 ])->columns(),
                 Forms\Components\Section::make('Access Info')->schema([
                     Forms\Components\Select::make('permissions')

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -46,6 +46,7 @@ class UserResource extends Resource
                 Forms\Components\Section::make('Personal Info')->schema([
                     Forms\Components\TextInput::make('username'),
                     Forms\Components\TextInput::make('email'),
+                    Forms\Components\DatePicker::make('email_verified_at')->label('Verified At'),
                     Forms\Components\DatePicker::make('date_register')->label('Created at')->disabled(),
                     Forms\Components\DatePicker::make('last_visited')->disabled(),
                 ])->columns(),

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -50,6 +50,7 @@ class User extends Authenticatable implements
         'agreed_at',
         'marketing_opt_in_at',
         'marketing_opt_out_at',
+        'email_verified_at',
         'has_sent_announcement',
         'last_interaction',
         'last_login',

--- a/public/changelog.md
+++ b/public/changelog.md
@@ -1,3 +1,9 @@
+### 2.2.11 - Confident Couatl
+#### June 1st, 2022
+- Fixed date-based events to not cause calendar to look simulate past years if it has a duration
+- Date-based events now supports insanely long durations (still HEAVILY discouraged)
+- Backend updates to be able to verify people's emails remotely 
+
 ### 2.2.10 - Concerned Couatl
 #### May 22nd, 2022
 - Fixed critical issue with event-based-events that could cause them to sometimes contain incorrect event

--- a/resources/js/calendar/calendar_workers.js
+++ b/resources/js/calendar/calendar_workers.js
@@ -179,6 +179,8 @@ const calendar_data_generator = {
 		for(let event_index = 0; event_index < this.events.length; event_index++){
 			let event = this.events[event_index];
 
+			if(event.data.date !== undefined && event.data.date.length === 3) continue;
+
 			this.pre_search = event.data.has_duration ? Math.max(event.data.duration, this.pre_search) : this.pre_search;
 			this.pre_search = event.data.limited_repeat ? Math.max(event.data.limited_repeat_num, this.pre_search) : this.pre_search;
 			this.pre_search = event.data.search_distance ? Math.max(event.data.search_distance, this.pre_search) : this.pre_search;
@@ -1371,7 +1373,7 @@ var event_evaluator = {
 
 					for(var duration = 1; duration < event.data.duration; duration++)
 					{
-						if(event_evaluator.event_data.valid[event_index].indexOf(epoch+duration-1) === -1 && epoch+duration >= event_evaluator.start_epoch) {
+						if(event_evaluator.event_data.valid[event_index].indexOf(epoch+duration-1) === -1 && epoch+duration >= event_evaluator.start_epoch && epoch+duration <= event_evaluator.end_epoch+1) {
 							event_evaluator.event_data.valid[event_index].push(epoch+duration-1);
 						}
 					}
@@ -1407,6 +1409,10 @@ var event_evaluator = {
 			if(lookback === undefined && lookahead === undefined){
 
 				lookback = 0;
+
+				if(current_event.data.date !== undefined && current_event.data.date.length === 3){
+				    return;
+                }
 
 				if(current_event.data.limited_repeat){
 					lookback = current_event.data.limited_repeat_num;

--- a/resources/js/calendar/calendar_workers.js
+++ b/resources/js/calendar/calendar_workers.js
@@ -1410,10 +1410,6 @@ var event_evaluator = {
 
 				lookback = 0;
 
-				if(current_event.data.date !== undefined && current_event.data.date.length === 3){
-				    return;
-                }
-
 				if(current_event.data.limited_repeat){
 					lookback = current_event.data.limited_repeat_num;
 				}

--- a/resources/views/layouts/calendar-grid.blade.php
+++ b/resources/views/layouts/calendar-grid.blade.php
@@ -15,7 +15,7 @@
         "
         @update-epochs.window="update_epochs"
         x-for="(timespan, index) in render_data.timespans"
-        :key="index + '-' + render_data.year"
+        :key="timespan.name + '-' + render_data.year + '-' + index"
     >
         <div class="timespan_container"
              :class='render_data.render_style'

--- a/resources/views/layouts/calendar-minimalistic.blade.php
+++ b/resources/views/layouts/calendar-minimalistic.blade.php
@@ -15,7 +15,7 @@
         "
         @update-epochs.window="update_epochs"
         x-for="timespan in render_data.timespans"
-        :key="index + '-' + render_data.year"
+        :key="timespan.name + '-' + render_data.year + '-' + index"
     >
 
         <div class="timespan_outer_container" x-show="loaded && render_data.timespans.length">

--- a/resources/views/layouts/calendar-vertical.blade.php
+++ b/resources/views/layouts/calendar-vertical.blade.php
@@ -15,7 +15,7 @@
         "
         @update-epochs.window="update_epochs"
         x-for="timespan in render_data.timespans"
-        :key="index + '-' + render_data.year"
+        :key="timespan.name + '-' + render_data.year + '-' + index"
     >
 
         <div class="timespan_container" :class='render_data.render_style' x-show="loaded && render_data.timespans.length">

--- a/resources/views/layouts/event.blade.php
+++ b/resources/views/layouts/event.blade.php
@@ -376,8 +376,8 @@
                             </div>
                         </div>
 
-                        <div class='limit_for_warning hidden row no-gutters p-2 mb-2 border rounded'>
-                            <p class='m-0'><strong>Use with caution.</strong> This setting will simulate to check dates backward to ensure consistency across the beginning of years. That process can take a while if this number is particularly high, like 50 or more.</p>
+                        <div x-show="working_event.data.limited_repeat" class='row no-gutters p-2 mb-2 border rounded'>
+                            <p class='m-0'><strong>Use with caution.</strong> This setting will simulate to check dates backward to ensure consistency across the beginning of years. That process can take a while if this number is particularly high, like 50 or more. Extremely high numbers <strong>could make your calendar unusable</strong>.</p>
                         </div>
 
                         <div class='row no-gutters'>
@@ -398,8 +398,8 @@
                             </div>
                         </div>
 
-                        <div class='duration_warning hidden row no-gutters p-2 mb-2 border rounded'>
-                            <p class='m-0'><strong>Use with caution.</strong> This setting will simulate to check dates backward/forward to ensure consistency across the beginning/end of years. That process can take a while if this number is particularly high, like 50 or more.</p>
+                        <div x-show="working_event.data.has_duration" class='row no-gutters p-2 mb-2 border rounded'>
+                            <p class='m-0'><strong>Use with caution.</strong> This setting will simulate to check dates backward/forward to ensure consistency across the beginning/end of years. That process can take a while if this number is particularly high, like 50 or more. Extremely high numbers <strong>could make your calendar unusable</strong>.</p>
                         </div>
 
                         <div class='row no-gutters mb-2'>


### PR DESCRIPTION
- Fixes single month render issues
- Fixes single-date events with crazy duration locking up calendars (now intelligently caps itself to the visible year)
- Re-added missing warning on edit event UI about using limited duration and duration sparingly