### PR TITLE
Fix Calendars Breaking Entire App When Date Cant Be Resolved

### DIFF
--- a/app/Models/Calendar.php
+++ b/app/Models/Calendar.php
@@ -375,15 +375,19 @@ class Calendar extends Model
      */
     public function getCurrentDateAttribute(): string
     {
-        if (!$this->current_date_valid) {
-            return "N/A";
+        try {
+            if (!$this->current_date_valid) {
+                return "N/A";
+            }
+
+            $year = $this->year;
+            $month = $this->month_name;
+            $day = $this->day;
+
+            return sprintf("%s %s, %s", $day, $month, $year);
+        } catch (\Throwable $e) {
+            return "[Error]";
         }
-
-        $year = $this->year;
-        $month = $this->month_name;
-        $day = $this->day;
-
-        return sprintf("%s %s, %s", $day, $month, $year);
     }
 
     /**


### PR DESCRIPTION
Currently, any time something winds up breaking the server-side version of the calendar's date retrieval, it breaks peoples' ability to access the calendar entirely - including our own!

This PR seeks to address that, showing just '[Error]' in place of the date as a first step.
