### PR TITLE
Attempt Vite Migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "postcss": "^8.4.21",
                 "progressbar.js": "^1.1.1",
                 "protip": "^1.4.21",
-                "sanitize-html": "^2.8.1",
+                "sanitize-html": "^2.11.0",
                 "select2": "^4.0.13",
                 "select2-bootstrap-theme": "0.1.0-beta.10",
                 "serverless-s3-sync": "^1.14.4",
@@ -41,13 +41,15 @@
                 "weather-icons": "git+https://github.com/fantasycalendar/weather-icons.git"
             },
             "devDependencies": {
+                "@rollup/plugin-inject": "^5.0.5",
+                "@vitejs/plugin-vue": "^5.0.3",
                 "axios": "^1.6.0",
                 "bootstrap": "^4.6.2",
                 "browser-sync": "^2.28.3",
                 "browser-sync-webpack-plugin": "2.3.0",
                 "cross-env": "^7.0.3",
                 "jquery": "^3.6.3",
-                "laravel-mix": "^6.0.49",
+                "laravel-vite-plugin": "^1.0.1",
                 "lodash": "^4.17.21",
                 "mix-tailwindcss": "^1.3.0",
                 "popper.js": "^1.16.1",
@@ -55,6 +57,9 @@
                 "sass": "^1.57.1",
                 "sass-loader": "^12.4.0",
                 "tippy.js": "^6.3.7",
+                "vite": "^5.1.0",
+                "vite-plugin-node-polyfills": "^0.19.0",
+                "vite-plugin-static-copy": "^1.0.1",
                 "webpack": "^5.76.0"
             },
             "optionalDependencies": {
@@ -82,6 +87,7 @@
             "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
             "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.0",
                 "@jridgewell/trace-mapping": "^0.3.9"
@@ -130,6 +136,7 @@
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
             "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/highlight": "^7.23.4",
                 "chalk": "^2.4.2"
@@ -143,6 +150,7 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "color-convert": "^1.9.0"
             },
@@ -155,6 +163,7 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -169,6 +178,7 @@
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "color-name": "1.1.3"
             }
@@ -177,13 +187,15 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.8.0"
             }
@@ -193,6 +205,7 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -202,6 +215,7 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "has-flag": "^3.0.0"
             },
@@ -214,6 +228,7 @@
             "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
             "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -223,6 +238,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
             "integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.23.5",
@@ -253,6 +269,7 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -269,13 +286,15 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@babel/core/node_modules/semver": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -285,6 +304,7 @@
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
             "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.23.6",
                 "@jridgewell/gen-mapping": "^0.3.2",
@@ -300,6 +320,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
             "integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.22.5"
             },
@@ -312,6 +333,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.22.15.tgz",
             "integrity": "sha512-QkBXwGgaoC2GtGZRoma6kv7Szfv06khvhFav67ZExau2RaXzy8MpHSMO2PNoP2XtmQphJQRHFfg77Bq731Yizw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.22.15"
             },
@@ -324,6 +346,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
             "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/compat-data": "^7.23.5",
                 "@babel/helper-validator-option": "^7.23.5",
@@ -340,6 +363,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -349,6 +373,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.9.tgz",
             "integrity": "sha512-B2L9neXTIyPQoXDm+NtovPvG6VOLWnaXu3BIeVDWwdKFgG30oNa6CqVGiJPDWQwIAK49t9gnQI9c6K6RzabiKw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
                 "@babel/helper-environment-visitor": "^7.22.20",
@@ -372,6 +397,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -381,6 +407,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.15.tgz",
             "integrity": "sha512-29FkPLFjn4TPEa3RE7GpW+qbE8tlsu3jntNYNfcGsc49LphF1PQIiD+vMZ1z1xVOKt+93khA9tc2JBs3kBjA7w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
                 "regexpu-core": "^5.3.1",
@@ -398,6 +425,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -407,6 +435,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.5.0.tgz",
             "integrity": "sha512-NovQquuQLAQ5HuyjCz7WQP9MjRj7dx++yspwiyUiGl9ZyadHRSql1HZh5ogRd8W8w6YM6EQ/NTB8rgjLt5W65Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-compilation-targets": "^7.22.6",
                 "@babel/helper-plugin-utils": "^7.22.5",
@@ -423,6 +452,7 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -439,13 +469,15 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@babel/helper-environment-visitor": {
             "version": "7.22.20",
             "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
             "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -455,6 +487,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
             "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/template": "^7.22.15",
                 "@babel/types": "^7.23.0"
@@ -468,6 +501,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
             "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.22.5"
             },
@@ -480,6 +514,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.23.0.tgz",
             "integrity": "sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.23.0"
             },
@@ -492,6 +527,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
             "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.22.15"
             },
@@ -504,6 +540,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
             "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.22.20",
                 "@babel/helper-module-imports": "^7.22.15",
@@ -523,6 +560,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz",
             "integrity": "sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.22.5"
             },
@@ -535,6 +573,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
             "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -544,6 +583,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.22.20.tgz",
             "integrity": "sha512-pBGyV4uBqOns+0UvhsTO8qgl8hO89PmiDYv+/COyp1aeMcmfrfruz+/nCMFiYyFF/Knn0yfrC85ZzNFjembFTw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
                 "@babel/helper-environment-visitor": "^7.22.20",
@@ -561,6 +601,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.20.tgz",
             "integrity": "sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.22.20",
                 "@babel/helper-member-expression-to-functions": "^7.22.15",
@@ -578,6 +619,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
             "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.22.5"
             },
@@ -590,6 +632,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz",
             "integrity": "sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.22.5"
             },
@@ -602,6 +645,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
             "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.22.5"
             },
@@ -614,6 +658,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
             "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -623,6 +668,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
             "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -632,6 +678,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
             "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -641,6 +688,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.20.tgz",
             "integrity": "sha512-pms/UwkOpnQe/PDAEdV/d7dVCoBbB+R4FvYoHGZz+4VPcg7RtYy2KP7S2lbuWM6FCSgob5wshfGESbC/hzNXZw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-function-name": "^7.22.5",
                 "@babel/template": "^7.22.15",
@@ -655,6 +703,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.9.tgz",
             "integrity": "sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/template": "^7.23.9",
                 "@babel/traverse": "^7.23.9",
@@ -669,6 +718,7 @@
             "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
             "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.22.20",
                 "chalk": "^2.4.2",
@@ -683,6 +733,7 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "color-convert": "^1.9.0"
             },
@@ -695,6 +746,7 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -709,6 +761,7 @@
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "color-name": "1.1.3"
             }
@@ -717,13 +770,15 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.8.0"
             }
@@ -733,6 +788,7 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -742,6 +798,7 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "has-flag": "^3.0.0"
             },
@@ -754,6 +811,7 @@
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.9.tgz",
             "integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -766,6 +824,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.23.3.tgz",
             "integrity": "sha512-iRkKcCqb7iGnq9+3G6rZ+Ciz5VywC4XNRHe57lKM+jOeYAoR0lVqdeeDRfh0tQcTfw/+vBhHn926FmQhLtlFLQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -781,6 +840,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.23.3.tgz",
             "integrity": "sha512-WwlxbfMNdVEpQjZmK5mhm7oSwD3dS6eU+Iwsi4Knl9wAletWem7kaRsGOG+8UEbRyqxY4SS5zvtfXwX+jMxUwQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
@@ -798,6 +858,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.23.7.tgz",
             "integrity": "sha512-LlRT7HgaifEpQA1ZgLVOIJZZFVPWN5iReq/7/JixwBtwcoeVGDBD53ZV28rrsLYOZs1Y/EHhA8N/Z6aazHR8cw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.22.20",
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -815,6 +876,7 @@
             "integrity": "sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==",
             "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/compat-data": "^7.20.5",
                 "@babel/helper-compilation-targets": "^7.20.7",
@@ -834,6 +896,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
             "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             },
@@ -846,6 +909,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
             "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -858,6 +922,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
             "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.12.13"
             },
@@ -870,6 +935,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
             "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -885,6 +951,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
             "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -897,6 +964,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
             "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.3"
             },
@@ -909,6 +977,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.23.3.tgz",
             "integrity": "sha512-lPgDSU+SJLK3xmFDTV2ZRQAiM7UuUjGidwBywFavObCiZc1BeAAcMtHJKUya92hPHO+at63JJPLygilZard8jw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -924,6 +993,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.23.3.tgz",
             "integrity": "sha512-pawnE0P9g10xgoP7yKr6CK63K2FMsTE+FZidZO/1PwRdzmAPVs+HS1mAURUsgaoxammTJvULUdIkEK0gOcU2tA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -939,6 +1009,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
             "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -951,6 +1022,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
             "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -963,6 +1035,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
             "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -975,6 +1048,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
             "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -987,6 +1061,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
             "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -999,6 +1074,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
             "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -1011,6 +1087,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
             "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -1023,6 +1100,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
             "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -1035,6 +1113,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
             "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -1050,6 +1129,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
             "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -1065,6 +1145,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
             "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-create-regexp-features-plugin": "^7.18.6",
                 "@babel/helper-plugin-utils": "^7.18.6"
@@ -1081,6 +1162,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.23.3.tgz",
             "integrity": "sha512-NzQcQrzaQPkaEwoTm4Mhyl8jI1huEL/WWIEvudjTCMJ9aBZNpsJbMASx7EQECtQQPS/DcnFpo0FIh3LvEO9cxQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -1096,6 +1178,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.9.tgz",
             "integrity": "sha512-8Q3veQEDGe14dTYuwagbRtwxQDnytyg1JFu4/HwEMETeofocrB0U0ejBJIXoeG/t2oXZ8kzCyI0ZZfbT80VFNQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.22.20",
                 "@babel/helper-plugin-utils": "^7.22.5",
@@ -1114,6 +1197,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.23.3.tgz",
             "integrity": "sha512-A7LFsKi4U4fomjqXJlZg/u0ft/n8/7n7lpffUP/ZULx/DtV9SGlNKZolHH6PE8Xl1ngCc0M11OaeZptXVkfKSw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.22.15",
                 "@babel/helper-plugin-utils": "^7.22.5",
@@ -1131,6 +1215,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.23.3.tgz",
             "integrity": "sha512-vI+0sIaPIO6CNuM9Kk5VmXcMVRiOpDh7w2zZt9GXzmE/9KD70CUEVhvPR/etAeNK/FAEkhxQtXOzVF3EuRL41A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -1146,6 +1231,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.23.4.tgz",
             "integrity": "sha512-0QqbP6B6HOh7/8iNR4CQU2Th/bbRtBp4KS9vcaZd1fZ0wSh5Fyssg0UCIHwxh+ka+pNDREbVLQnHCMHKZfPwfw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -1161,6 +1247,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.23.3.tgz",
             "integrity": "sha512-uM+AN8yCIjDPccsKGlw271xjJtGii+xQIF/uMPS8H15L12jZTsLfF4o5vNO7d/oUguOyfdikHGc/yi9ge4SGIg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-create-class-features-plugin": "^7.22.15",
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -1177,6 +1264,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.23.4.tgz",
             "integrity": "sha512-nsWu/1M+ggti1SOALj3hfx5FXzAY06fwPJsUZD4/A5e1bWi46VUIWtD+kOX6/IdhXGsXBWllLFDSnqSCdUNydQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-create-class-features-plugin": "^7.22.15",
                 "@babel/helper-plugin-utils": "^7.22.5",
@@ -1194,6 +1282,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.8.tgz",
             "integrity": "sha512-yAYslGsY1bX6Knmg46RjiCiNSwJKv2IUC8qOdYKqMMr0491SXFhcHqOdRDeCRohOOIzwN/90C6mQ9qAKgrP7dg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
                 "@babel/helper-compilation-targets": "^7.23.6",
@@ -1216,6 +1305,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.23.3.tgz",
             "integrity": "sha512-dTj83UVTLw/+nbiHqQSFdwO9CbTtwq1DsDqm3CUEtDrZNET5rT5E6bIdTlOftDTDLMYxvxHNEYO4B9SLl8SLZw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/template": "^7.22.15"
@@ -1232,6 +1322,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.23.3.tgz",
             "integrity": "sha512-n225npDqjDIr967cMScVKHXJs7rout1q+tt50inyBCPkyZ8KxeI6d+GIbSBTT/w/9WdlWDOej3V9HE5Lgk57gw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -1247,6 +1338,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.23.3.tgz",
             "integrity": "sha512-vgnFYDHAKzFaTVp+mneDsIEbnJ2Np/9ng9iviHw3P/KVcgONxpNULEW/51Z/BaFojG2GI2GwwXck5uV1+1NOYQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-create-regexp-features-plugin": "^7.22.15",
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -1263,6 +1355,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.23.3.tgz",
             "integrity": "sha512-RrqQ+BQmU3Oyav3J+7/myfvRCq7Tbz+kKLLshUmMwNlDHExbGL7ARhajvoBJEvc+fCguPPu887N+3RRXBVKZUA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -1278,6 +1371,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.23.4.tgz",
             "integrity": "sha512-V6jIbLhdJK86MaLh4Jpghi8ho5fGzt3imHOBu/x0jlBaPYqDoWz4RDXjmMOfnh+JWNaQleEAByZLV0QzBT4YQQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/plugin-syntax-dynamic-import": "^7.8.3"
@@ -1294,6 +1388,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.23.3.tgz",
             "integrity": "sha512-5fhCsl1odX96u7ILKHBj4/Y8vipoqwsJMh4csSA8qFfxrZDEA4Ssku2DyNvMJSmZNOEBT750LfFPbtrnTP90BQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-builder-binary-assignment-operator-visitor": "^7.22.15",
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -1310,6 +1405,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.23.4.tgz",
             "integrity": "sha512-GzuSBcKkx62dGzZI1WVgTWvkkz84FZO5TC5T8dl/Tht/rAla6Dg/Mz9Yhypg+ezVACf/rgDuQt3kbWEv7LdUDQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
@@ -1326,6 +1422,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.23.6.tgz",
             "integrity": "sha512-aYH4ytZ0qSuBbpfhuofbg/e96oQ7U2w1Aw/UQmKT+1l39uEhUPoFS3fHevDc1G0OvewyDudfMKY1OulczHzWIw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
@@ -1342,6 +1439,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.23.3.tgz",
             "integrity": "sha512-I1QXp1LxIvt8yLaib49dRW5Okt7Q4oaxao6tFVKS/anCdEOMtYwWVKoiOA1p34GOWIZjUK0E+zCp7+l1pfQyiw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-compilation-targets": "^7.22.15",
                 "@babel/helper-function-name": "^7.23.0",
@@ -1359,6 +1457,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.23.4.tgz",
             "integrity": "sha512-81nTOqM1dMwZ/aRXQ59zVubN9wHGqk6UtqRK+/q+ciXmRy8fSolhGVvG09HHRGo4l6fr/c4ZhXUQH0uFW7PZbg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/plugin-syntax-json-strings": "^7.8.3"
@@ -1375,6 +1474,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.23.3.tgz",
             "integrity": "sha512-wZ0PIXRxnwZvl9AYpqNUxpZ5BiTGrYt7kueGQ+N5FiQ7RCOD4cm8iShd6S6ggfVIWaJf2EMk8eRzAh52RfP4rQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -1390,6 +1490,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.23.4.tgz",
             "integrity": "sha512-Mc/ALf1rmZTP4JKKEhUwiORU+vcfarFVLfcFiolKUo6sewoxSEgl36ak5t+4WamRsNr6nzjZXQjM35WsU+9vbg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
@@ -1406,6 +1507,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.23.3.tgz",
             "integrity": "sha512-sC3LdDBDi5x96LA+Ytekz2ZPk8i/Ck+DEuDbRAll5rknJ5XRTSaPKEYwomLcs1AA8wg9b3KjIQRsnApj+q51Ag==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -1421,6 +1523,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.23.3.tgz",
             "integrity": "sha512-vJYQGxeKM4t8hYCKVBlZX/gtIY2I7mRGFNcm85sgXGMTBcoV3QdVtdpbcWEbzbfUIUZKwvgFT82mRvaQIebZzw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-module-transforms": "^7.23.3",
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -1437,6 +1540,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.23.3.tgz",
             "integrity": "sha512-aVS0F65LKsdNOtcz6FRCpE4OgsP2OFnW46qNxNIX9h3wuzaNcSQsJysuMwqSibC98HPrf2vCgtxKNwS0DAlgcA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-module-transforms": "^7.23.3",
                 "@babel/helper-plugin-utils": "^7.22.5",
@@ -1454,6 +1558,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.9.tgz",
             "integrity": "sha512-KDlPRM6sLo4o1FkiSlXoAa8edLXFsKKIda779fbLrvmeuc3itnjCtaO6RrtoaANsIJANj+Vk1zqbZIMhkCAHVw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-hoist-variables": "^7.22.5",
                 "@babel/helper-module-transforms": "^7.23.3",
@@ -1472,6 +1577,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.23.3.tgz",
             "integrity": "sha512-zHsy9iXX2nIsCBFPud3jKn1IRPWg3Ing1qOZgeKV39m1ZgIdpJqvlWVeiHBZC6ITRG0MfskhYe9cLgntfSFPIg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-module-transforms": "^7.23.3",
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -1488,6 +1594,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.22.5.tgz",
             "integrity": "sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-create-regexp-features-plugin": "^7.22.5",
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -1504,6 +1611,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.23.3.tgz",
             "integrity": "sha512-YJ3xKqtJMAT5/TIZnpAR3I+K+WaDowYbN3xyxI8zxx/Gsypwf9B9h0VB+1Nh6ACAAPRS5NSRje0uVv5i79HYGQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -1519,6 +1627,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.23.4.tgz",
             "integrity": "sha512-jHE9EVVqHKAQx+VePv5LLGHjmHSJR76vawFPTdlxR/LVJPfOEGxREQwQfjuZEOPTwG92X3LINSh3M40Rv4zpVA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
@@ -1535,6 +1644,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.23.4.tgz",
             "integrity": "sha512-mps6auzgwjRrwKEZA05cOwuDc9FAzoyFS4ZsG/8F43bTLf/TgkJg7QXOrPO1JO599iA3qgK9MXdMGOEC8O1h6Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/plugin-syntax-numeric-separator": "^7.10.4"
@@ -1551,6 +1661,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.23.4.tgz",
             "integrity": "sha512-9x9K1YyeQVw0iOXJlIzwm8ltobIIv7j2iLyP2jIhEbqPRQ7ScNgwQufU2I0Gq11VjyG4gI4yMXt2VFags+1N3g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/compat-data": "^7.23.3",
                 "@babel/helper-compilation-targets": "^7.22.15",
@@ -1570,6 +1681,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.23.3.tgz",
             "integrity": "sha512-BwQ8q0x2JG+3lxCVFohg+KbQM7plfpBwThdW9A6TMtWwLsbDA01Ek2Zb/AgDN39BiZsExm4qrXxjk+P1/fzGrA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/helper-replace-supers": "^7.22.20"
@@ -1586,6 +1698,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.23.4.tgz",
             "integrity": "sha512-XIq8t0rJPHf6Wvmbn9nFxU6ao4c7WhghTR5WyV8SrJfUFzyxhCm4nhC+iAp3HFhbAKLfYpgzhJ6t4XCtVwqO5A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
@@ -1602,6 +1715,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.23.4.tgz",
             "integrity": "sha512-ZU8y5zWOfjM5vZ+asjgAPwDaBjJzgufjES89Rs4Lpq63O300R/kOz30WCLo6BxxX6QVEilwSlpClnG5cZaikTA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
@@ -1619,6 +1733,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.23.3.tgz",
             "integrity": "sha512-09lMt6UsUb3/34BbECKVbVwrT9bO6lILWln237z7sLaWnMsTi7Yc9fhX5DLpkJzAGfaReXI22wP41SZmnAA3Vw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -1634,6 +1749,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.23.3.tgz",
             "integrity": "sha512-UzqRcRtWsDMTLrRWFvUBDwmw06tCQH9Rl1uAjfh6ijMSmGYQ+fpdB+cnqRC8EMh5tuuxSv0/TejGL+7vyj+50g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-create-class-features-plugin": "^7.22.15",
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -1650,6 +1766,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.23.4.tgz",
             "integrity": "sha512-9G3K1YqTq3F4Vt88Djx1UZ79PDyj+yKRnUy7cZGSMe+a7jkwD259uKKuUzQlPkGam7R+8RJwh5z4xO27fA1o2A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
                 "@babel/helper-create-class-features-plugin": "^7.22.15",
@@ -1668,6 +1785,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.23.3.tgz",
             "integrity": "sha512-jR3Jn3y7cZp4oEWPFAlRsSWjxKe4PZILGBSd4nis1TsC5qeSpb+nrtihJuDhNI7QHiVbUaiXa0X2RZY3/TI6Nw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -1683,6 +1801,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.23.3.tgz",
             "integrity": "sha512-KP+75h0KghBMcVpuKisx3XTu9Ncut8Q8TuvGO4IhY+9D5DFEckQefOuIsB/gQ2tG71lCke4NMrtIPS8pOj18BQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "regenerator-transform": "^0.15.2"
@@ -1699,6 +1818,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.23.3.tgz",
             "integrity": "sha512-QnNTazY54YqgGxwIexMZva9gqbPa15t/x9VS+0fsEFWplwVpXYZivtgl43Z1vMpc1bdPP2PP8siFeVcnFvA3Cg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -1714,6 +1834,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.9.tgz",
             "integrity": "sha512-A7clW3a0aSjm3ONU9o2HAILSegJCYlEZmOhmBRReVtIpY/Z/p7yIZ+wR41Z+UipwdGuqwtID/V/dOdZXjwi9gQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.22.15",
                 "@babel/helper-plugin-utils": "^7.22.5",
@@ -1734,6 +1855,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -1743,6 +1865,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.23.3.tgz",
             "integrity": "sha512-ED2fgqZLmexWiN+YNFX26fx4gh5qHDhn1O2gvEhreLW2iI63Sqm4llRLCXALKrCnbN4Jy0VcMQZl/SAzqug/jg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -1758,6 +1881,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.23.3.tgz",
             "integrity": "sha512-VvfVYlrlBVu+77xVTOAoxQ6mZbnIq5FM0aGBSFEcIh03qHf+zNqA4DC/3XMUozTg7bZV3e3mZQ0i13VB6v5yUg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
@@ -1774,6 +1898,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.23.3.tgz",
             "integrity": "sha512-HZOyN9g+rtvnOU3Yh7kSxXrKbzgrm5X4GncPY1QOquu7epga5MxKHVpYu2hvQnry/H+JjckSYRb93iNfsioAGg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -1789,6 +1914,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.23.3.tgz",
             "integrity": "sha512-Flok06AYNp7GV2oJPZZcP9vZdszev6vPBkHLwxwSpaIqx75wn6mUd3UFWsSsA0l8nXAKkyCmL/sR02m8RYGeHg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -1804,6 +1930,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.23.3.tgz",
             "integrity": "sha512-4t15ViVnaFdrPC74be1gXBSMzXk3B4Us9lP7uLRQHTFpV5Dvt33pn+2MyyNxmN3VTTm3oTrZVMUmuw3oBnQ2oQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -1819,6 +1946,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.23.3.tgz",
             "integrity": "sha512-OMCUx/bU6ChE3r4+ZdylEqAjaQgHAgipgW8nsCfu5pGqDcFytVd91AwRvUJSBZDz0exPGgnjoqhgRYLRjFZc9Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
@@ -1834,6 +1962,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.23.3.tgz",
             "integrity": "sha512-KcLIm+pDZkWZQAFJ9pdfmh89EwVfmNovFBcXko8szpBeF8z68kWIPeKlmSOkT9BXJxs2C0uk+5LxoxIv62MROA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-create-regexp-features-plugin": "^7.22.15",
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -1850,6 +1979,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.23.3.tgz",
             "integrity": "sha512-wMHpNA4x2cIA32b/ci3AfwNgheiva2W0WUKWTK7vBHBhDKfPsc5cFGNWm69WBqpwd86u1qwZ9PWevKqm1A3yAw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-create-regexp-features-plugin": "^7.22.15",
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -1866,6 +1996,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.23.3.tgz",
             "integrity": "sha512-W7lliA/v9bNR83Qc3q1ip9CQMZ09CcHDbHfbLRDNuAhn1Mvkr1ZNF7hPmztMQvtTGVLJ9m8IZqWsTkXOml8dbw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-create-regexp-features-plugin": "^7.22.15",
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -1882,6 +2013,7 @@
             "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.9.tgz",
             "integrity": "sha512-3kBGTNBBk9DQiPoXYS0g0BYlwTQYUTifqgKTjxUwEUkduRT2QOa0FPGBJ+NROQhGyYO5BuTJwGvBnqKDykac6A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/compat-data": "^7.23.5",
                 "@babel/helper-compilation-targets": "^7.23.6",
@@ -1976,6 +2108,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -1985,6 +2118,7 @@
             "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
             "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@babel/types": "^7.4.4",
@@ -1998,13 +2132,15 @@
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz",
             "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@babel/runtime": {
             "version": "7.23.9",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
             "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
             },
@@ -2017,6 +2153,7 @@
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
             "integrity": "sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.23.5",
                 "@babel/parser": "^7.23.9",
@@ -2031,6 +2168,7 @@
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.9.tgz",
             "integrity": "sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.23.5",
                 "@babel/generator": "^7.23.6",
@@ -2052,6 +2190,7 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -2068,13 +2207,15 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@babel/types": {
             "version": "7.23.9",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.9.tgz",
             "integrity": "sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-string-parser": "^7.23.4",
                 "@babel/helper-validator-identifier": "^7.22.20",
@@ -2090,6 +2231,7 @@
             "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
             "dev": true,
             "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.1.90"
             }
@@ -2099,8 +2241,377 @@
             "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
             "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
+            "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
+            "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
+            "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
+            "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
+            "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
+            "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
+            "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
+            "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
+            "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
+            "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
+            "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
+            "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
+            "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
+            "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
+            "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
+            "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
+            "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
+            "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
+            "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
+            "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
+            "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
+            "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
+            "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/@fortawesome/fontawesome-free": {
@@ -2272,7 +2783,8 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
             "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -2325,6 +2837,219 @@
                 "url": "https://opencollective.com/popperjs"
             }
         },
+        "node_modules/@rollup/plugin-inject": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
+            "integrity": "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/pluginutils": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+            "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.6.tgz",
+            "integrity": "sha512-MVNXSSYN6QXOulbHpLMKYi60ppyO13W9my1qogeiAqtjb2yR4LSmfU2+POvDkLzhjYLXz9Rf9+9a3zFHW1Lecg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.6.tgz",
+            "integrity": "sha512-T14aNLpqJ5wzKNf5jEDpv5zgyIqcpn1MlwCrUXLrwoADr2RkWA0vOWP4XxbO9aiO3dvMCQICZdKeDrFl7UMClw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.6.tgz",
+            "integrity": "sha512-CqNNAyhRkTbo8VVZ5R85X73H3R5NX9ONnKbXuHisGWC0qRbTTxnF1U4V9NafzJbgGM0sHZpdO83pLPzq8uOZFw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.6.tgz",
+            "integrity": "sha512-zRDtdJuRvA1dc9Mp6BWYqAsU5oeLixdfUvkTHuiYOHwqYuQ4YgSmi6+/lPvSsqc/I0Omw3DdICx4Tfacdzmhog==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.6.tgz",
+            "integrity": "sha512-oNk8YXDDnNyG4qlNb6is1ojTOGL/tRhbbKeE/YuccItzerEZT68Z9gHrY3ROh7axDc974+zYAPxK5SH0j/G+QQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.6.tgz",
+            "integrity": "sha512-Z3O60yxPtuCYobrtzjo0wlmvDdx2qZfeAWTyfOjEDqd08kthDKexLpV97KfAeUXPosENKd8uyJMRDfFMxcYkDQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.6.tgz",
+            "integrity": "sha512-gpiG0qQJNdYEVad+1iAsGAbgAnZ8j07FapmnIAQgODKcOTjLEWM9sRb+MbQyVsYCnA0Im6M6QIq6ax7liws6eQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.6.tgz",
+            "integrity": "sha512-+uCOcvVmFUYvVDr27aiyun9WgZk0tXe7ThuzoUTAukZJOwS5MrGbmSlNOhx1j80GdpqbOty05XqSl5w4dQvcOA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.6.tgz",
+            "integrity": "sha512-HUNqM32dGzfBKuaDUBqFB7tP6VMN74eLZ33Q9Y1TBqRDn+qDonkAUyKWwF9BR9unV7QUzffLnz9GrnKvMqC/fw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.6.tgz",
+            "integrity": "sha512-ch7M+9Tr5R4FK40FHQk8VnML0Szi2KRujUgHXd/HjuH9ifH72GUmw6lStZBo3c3GB82vHa0ZoUfjfcM7JiiMrQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.6.tgz",
+            "integrity": "sha512-VD6qnR99dhmTQ1mJhIzXsRcTBvTjbfbGGwKAHcu+52cVl15AC/kplkhxzW/uT0Xl62Y/meBKDZvoJSJN+vTeGA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.6.tgz",
+            "integrity": "sha512-J9AFDq/xiRI58eR2NIDfyVmTYGyIZmRcvcAoJ48oDld/NTR8wyiPUu2X/v1navJ+N/FGg68LEbX3Ejd6l8B7MQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.6.tgz",
+            "integrity": "sha512-jqzNLhNDvIZOrt69Ce4UjGRpXJBzhUBzawMwnaDAwyHriki3XollsewxWzOzz+4yOFDkuJHtTsZFwMxhYJWmLQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/@socket.io/component-emitter": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
@@ -2369,6 +3094,7 @@
             "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
             "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10.13.0"
             }
@@ -2378,6 +3104,7 @@
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
             "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.20.7",
                 "@babel/types": "^7.20.7",
@@ -2391,6 +3118,7 @@
             "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
             "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.0.0"
             }
@@ -2400,6 +3128,7 @@
             "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
             "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.1.0",
                 "@babel/types": "^7.0.0"
@@ -2410,6 +3139,7 @@
             "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.5.tgz",
             "integrity": "sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.20.7"
             }
@@ -2419,6 +3149,7 @@
             "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
             "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/connect": "*",
                 "@types/node": "*"
@@ -2429,6 +3160,7 @@
             "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.13.tgz",
             "integrity": "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -2438,6 +3170,7 @@
             "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.11.tgz",
             "integrity": "sha512-Y8n81lQVTAfP2TOdtJJEsCoYl1AnOkqDqMvXb9/7pfgZZ7r8YrEyurrAvAoAjHOGXKRybay+5CsExqIH6liccw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "source-map": "^0.6.0"
@@ -2448,6 +3181,7 @@
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
             "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -2457,6 +3191,7 @@
             "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz",
             "integrity": "sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/express-serve-static-core": "*",
                 "@types/node": "*"
@@ -2508,6 +3243,7 @@
             "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
             "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^4.17.33",
@@ -2520,6 +3256,7 @@
             "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.42.tgz",
             "integrity": "sha512-ckM3jm2bf/MfB3+spLPWYPUH573plBFwpOhqQ2WottxYV85j1HQFlxmnTq57X1yHY9awZPig06hL/cLMgNWHIQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "@types/qs": "*",
@@ -2532,6 +3269,7 @@
             "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
             "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/minimatch": "*",
                 "@types/node": "*"
@@ -2541,13 +3279,15 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
             "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@types/http-proxy": {
             "version": "1.17.14",
             "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.14.tgz",
             "integrity": "sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -2557,6 +3297,7 @@
             "resolved": "https://registry.npmjs.org/@types/imagemin/-/imagemin-8.0.5.tgz",
             "integrity": "sha512-tah3dm+5sG+fEDAz6CrQ5evuEaPX9K6DF3E5a01MPOKhA2oGBoC+oA5EJzSugB905sN4DE19EDzldT2Cld2g6Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -2566,6 +3307,7 @@
             "resolved": "https://registry.npmjs.org/@types/imagemin-gifsicle/-/imagemin-gifsicle-7.0.4.tgz",
             "integrity": "sha512-ZghMBd/Jgqg5utTJNPmvf6DkuHzMhscJ8vgf/7MUGCpO+G+cLrhYltL+5d+h3A1B4W73S2SrmJZ1jS5LACpX+A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/imagemin": "*"
             }
@@ -2575,6 +3317,7 @@
             "resolved": "https://registry.npmjs.org/@types/imagemin-mozjpeg/-/imagemin-mozjpeg-8.0.4.tgz",
             "integrity": "sha512-ZCAxV8SYJB8ehwHpnbRpHjg5Wc4HcyuAMiDhXbkgC7gujDoOTyHO3dhDkUtZ1oK1DLBRZapqG9etdLVhUml7yQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/imagemin": "*"
             }
@@ -2584,6 +3327,7 @@
             "resolved": "https://registry.npmjs.org/@types/imagemin-optipng/-/imagemin-optipng-5.2.4.tgz",
             "integrity": "sha512-mvKnDMC8eCYZetAQudjs1DbgpR84WhsTx1wgvdiXnpuUEti3oJ+MaMYBRWPY0JlQ4+y4TXKOfa7+LOuT8daegQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/imagemin": "*"
             }
@@ -2593,6 +3337,7 @@
             "resolved": "https://registry.npmjs.org/@types/imagemin-svgo/-/imagemin-svgo-8.0.1.tgz",
             "integrity": "sha512-YafkdrVAcr38U0Ln1C+L1n4SIZqC47VBHTyxCq7gTUSd1R9MdIvMcrljWlgU1M9O68WZDeQWUrKipKYfEOCOvQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/imagemin": "*",
                 "@types/svgo": "^1"
@@ -2621,13 +3366,15 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
             "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@types/minimatch": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
             "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@types/node": {
             "version": "20.11.13",
@@ -2643,6 +3390,7 @@
             "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
             "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -2651,31 +3399,36 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
             "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@types/qs": {
             "version": "6.9.11",
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
             "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@types/range-parser": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
             "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@types/retry": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
             "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@types/send": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
             "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/mime": "^1",
                 "@types/node": "*"
@@ -2686,6 +3439,7 @@
             "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.4.tgz",
             "integrity": "sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/express": "*"
             }
@@ -2695,6 +3449,7 @@
             "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
             "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/http-errors": "*",
                 "@types/mime": "*",
@@ -2706,6 +3461,7 @@
             "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.36.tgz",
             "integrity": "sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -2714,16 +3470,126 @@
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/@types/svgo/-/svgo-1.3.6.tgz",
             "integrity": "sha512-AZU7vQcy/4WFEuwnwsNsJnFwupIpbllH1++LXScN6uxT1Z4zPzdrWG97w4/I7eFKFTvfy/bHFStWjdBAg2Vjug==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@types/ws": {
             "version": "8.5.10",
             "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
             "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
+        },
+        "node_modules/@vitejs/plugin-vue": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.3.tgz",
+            "integrity": "sha512-b8S5dVS40rgHdDrw+DQi/xOM9ed+kSRZzfm1T74bMmBDCd8XO87NKlFYInzCtwvtWwXZvo1QxE2OSspTATWrbA==",
+            "dev": true,
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "peerDependencies": {
+                "vite": "^5.0.0",
+                "vue": "^3.2.25"
+            }
+        },
+        "node_modules/@vue/compiler-core": {
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.17.tgz",
+            "integrity": "sha512-SLECdJMmOSfQhRom6WqisORfZe5cgfOypXuwK3UEeDXbof5J0fK2pj0sc79E9Z+o4npACzrF3eqf3FhPOZcXyw==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/parser": "^7.23.9",
+                "@vue/shared": "3.4.17",
+                "entities": "^4.5.0",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.0.2"
+            }
+        },
+        "node_modules/@vue/compiler-core/node_modules/@vue/shared": {
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.17.tgz",
+            "integrity": "sha512-BKloFjdOdVMnYVEKHzPHhJA5wW4iNzuUdEtj1F3phjHMSC269XcQl+L4cZ9EgbYyC/XuEYgn/ICV3VNmnDoH6g==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@vue/compiler-core/node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/@vue/compiler-dom": {
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.17.tgz",
+            "integrity": "sha512-gXWh0G6rJjuOg62RGNM5sIj/AdcVXfJYRpaxexujaJqHmqdUP/9J3QzKUNadrLw5U98UWvVPpfriT2RVSUmx/w==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-core": "3.4.17",
+                "@vue/shared": "3.4.17"
+            }
+        },
+        "node_modules/@vue/compiler-dom/node_modules/@vue/shared": {
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.17.tgz",
+            "integrity": "sha512-BKloFjdOdVMnYVEKHzPHhJA5wW4iNzuUdEtj1F3phjHMSC269XcQl+L4cZ9EgbYyC/XuEYgn/ICV3VNmnDoH6g==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@vue/compiler-sfc": {
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.17.tgz",
+            "integrity": "sha512-rYWyfugylV69bFzWuyCS2VgQY9XpY1yfWRQrykct1dORhA57ppss1LtIo9pAzMf+XIe+ZZV8IPGSw6fbV+8SYg==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/parser": "^7.23.9",
+                "@vue/compiler-core": "3.4.17",
+                "@vue/compiler-dom": "3.4.17",
+                "@vue/compiler-ssr": "3.4.17",
+                "@vue/shared": "3.4.17",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.6",
+                "postcss": "^8.4.33",
+                "source-map-js": "^1.0.2"
+            }
+        },
+        "node_modules/@vue/compiler-sfc/node_modules/@vue/shared": {
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.17.tgz",
+            "integrity": "sha512-BKloFjdOdVMnYVEKHzPHhJA5wW4iNzuUdEtj1F3phjHMSC269XcQl+L4cZ9EgbYyC/XuEYgn/ICV3VNmnDoH6g==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@vue/compiler-ssr": {
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.17.tgz",
+            "integrity": "sha512-08S6EZkAOsQSuIt6djF3wbkKwlUCvB/DlKCHgirVpLTSIkwLEw7E8K0fGsgTbbGtO3nsY8Y6uBbWm9ZGFif70Q==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-dom": "3.4.17",
+                "@vue/shared": "3.4.17"
+            }
+        },
+        "node_modules/@vue/compiler-ssr/node_modules/@vue/shared": {
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.17.tgz",
+            "integrity": "sha512-BKloFjdOdVMnYVEKHzPHhJA5wW4iNzuUdEtj1F3phjHMSC269XcQl+L4cZ9EgbYyC/XuEYgn/ICV3VNmnDoH6g==",
+            "dev": true,
+            "peer": true
         },
         "node_modules/@vue/reactivity": {
             "version": "3.1.5",
@@ -2732,6 +3598,74 @@
             "dependencies": {
                 "@vue/shared": "3.1.5"
             }
+        },
+        "node_modules/@vue/runtime-core": {
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.17.tgz",
+            "integrity": "sha512-XtHbp01ycEnOEjNvwFhuEnhaXF0NvcYc1SsWW5u15jj0IZRUGzx3qnIt3pl+i/uhwNDerfEL1mvgRpcVPc4osw==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@vue/reactivity": "3.4.17",
+                "@vue/shared": "3.4.17"
+            }
+        },
+        "node_modules/@vue/runtime-core/node_modules/@vue/reactivity": {
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.17.tgz",
+            "integrity": "sha512-xpgg9b8XI+o+vALHHt/260bd4rZtHo8hp5djrF7kz3jU5NDWfVliXyF8y67sIDyLihkjbFG1vRKSeJfxCBpViQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@vue/shared": "3.4.17"
+            }
+        },
+        "node_modules/@vue/runtime-core/node_modules/@vue/shared": {
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.17.tgz",
+            "integrity": "sha512-BKloFjdOdVMnYVEKHzPHhJA5wW4iNzuUdEtj1F3phjHMSC269XcQl+L4cZ9EgbYyC/XuEYgn/ICV3VNmnDoH6g==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@vue/runtime-dom": {
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.17.tgz",
+            "integrity": "sha512-19U7LLsDALEpKMSoSH60yUCh7YnJZoUNYnXoV6tahQj4jYAuQVvbcFOJi7er5m7Cm2P79iTNfpYEHtTAUtU9rw==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@vue/runtime-core": "3.4.17",
+                "@vue/shared": "3.4.17",
+                "csstype": "^3.1.3"
+            }
+        },
+        "node_modules/@vue/runtime-dom/node_modules/@vue/shared": {
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.17.tgz",
+            "integrity": "sha512-BKloFjdOdVMnYVEKHzPHhJA5wW4iNzuUdEtj1F3phjHMSC269XcQl+L4cZ9EgbYyC/XuEYgn/ICV3VNmnDoH6g==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@vue/server-renderer": {
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.17.tgz",
+            "integrity": "sha512-ImmlPjysrWO8R8i6puoa0WbMWXW7gUAq4EHqjniNDWEWzcggp+KL2VLFKYLHAZl5FcgK0nyXgufEiXbbUwUd8g==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-ssr": "3.4.17",
+                "@vue/shared": "3.4.17"
+            },
+            "peerDependencies": {
+                "vue": "3.4.17"
+            }
+        },
+        "node_modules/@vue/server-renderer/node_modules/@vue/shared": {
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.17.tgz",
+            "integrity": "sha512-BKloFjdOdVMnYVEKHzPHhJA5wW4iNzuUdEtj1F3phjHMSC269XcQl+L4cZ9EgbYyC/XuEYgn/ICV3VNmnDoH6g==",
+            "dev": true,
+            "peer": true
         },
         "node_modules/@vue/shared": {
             "version": "3.1.5",
@@ -2889,6 +3823,7 @@
             "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
             "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
             "dev": true,
+            "peer": true,
             "peerDependencies": {
                 "webpack": "4.x.x || 5.x.x",
                 "webpack-cli": "4.x.x"
@@ -2899,6 +3834,7 @@
             "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
             "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "envinfo": "^7.7.3"
             },
@@ -2911,6 +3847,7 @@
             "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
             "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
             "dev": true,
+            "peer": true,
             "peerDependencies": {
                 "webpack-cli": "4.x.x"
             },
@@ -3000,6 +3937,7 @@
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
             "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ajv": "^8.0.0"
             },
@@ -3017,6 +3955,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
             "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -3032,7 +3971,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/ajv-keywords": {
             "version": "3.5.2",
@@ -3064,6 +4004,7 @@
             "engines": [
                 "node >= 0.8.0"
             ],
+            "peer": true,
             "bin": {
                 "ansi-html": "bin/ansi-html"
             }
@@ -3116,13 +4057,15 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
             "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/array-union": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
             "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3150,6 +4093,7 @@
             "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.1.tgz",
             "integrity": "sha512-zzw1uCAgLbsKwBfFc8CX78DDg+xZeBksSO3vwVIDDN5i94eOrPsSSyiVhmsSABFDM/OcpE2aagCat9dnWQLG1A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "object.assign": "^4.1.4",
                 "util": "^0.10.4"
@@ -3159,13 +4103,15 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/assert/node_modules/util": {
             "version": "0.10.4",
             "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
             "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "inherits": "2.0.3"
             }
@@ -3316,6 +4262,7 @@
             "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.3.0.tgz",
             "integrity": "sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "find-cache-dir": "^3.3.1",
                 "loader-utils": "^2.0.0",
@@ -3335,6 +4282,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.8.tgz",
             "integrity": "sha512-OtIuQfafSzpo/LhnJaykc0R/MMnuLSSVjVYy9mHArIZ9qTCSZ6TpWCuEKZYVoN//t8HqBNScHrOtCrIK5IaGLg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/compat-data": "^7.22.6",
                 "@babel/helper-define-polyfill-provider": "^0.5.0",
@@ -3349,6 +4297,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -3358,6 +4307,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.9.0.tgz",
             "integrity": "sha512-7nZPG1uzK2Ymhy/NbaOWTg3uibM2BmGASS4vHS4szRZAIR8R6GwA/xAujpdrXU5iyklrimWnLWU+BLF9suPTqg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-define-polyfill-provider": "^0.5.0",
                 "core-js-compat": "^3.34.0"
@@ -3371,6 +4321,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.5.tgz",
             "integrity": "sha512-OJGYZlhLqBh2DDHeqAxWB1XIvr49CxiJ2gIt61/PU55CQK4Z58OzMqjDe1zwQdQk+rBYsRc+1rJmdajM3gimHg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/helper-define-polyfill-provider": "^0.5.0"
             },
@@ -3450,6 +4401,7 @@
             "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
             "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "bytes": "3.1.2",
                 "content-type": "~1.0.4",
@@ -3474,6 +4426,7 @@
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
             "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.8",
                 "npm": "1.2.8000 || >= 1.4.16"
@@ -3484,6 +4437,7 @@
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
             "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ee-first": "1.1.1"
             },
@@ -3496,6 +4450,7 @@
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
             "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "side-channel": "^1.0.4"
             },
@@ -3511,6 +4466,7 @@
             "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
             "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "bytes": "3.1.2",
                 "http-errors": "2.0.0",
@@ -3526,6 +4482,7 @@
             "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.2.1.tgz",
             "integrity": "sha512-oSzCS2zV14bh2kji6vNe7vrpJYCHGvcZnlffFQ1MEoX/WOeQ/teD8SYWKR942OI3INjq8OMNJlbPK5LLLUxFDw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "multicast-dns": "^7.2.5"
@@ -3535,7 +4492,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
             "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/bootstrap": {
             "version": "4.6.2",
@@ -3587,6 +4545,15 @@
             "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
             "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
             "dev": true
+        },
+        "node_modules/browser-resolve": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
+            "integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
+            "dev": true,
+            "dependencies": {
+                "resolve": "^1.17.0"
+            }
         },
         "node_modules/browser-split": {
             "version": "0.0.0",
@@ -3860,6 +4827,7 @@
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -3869,6 +4837,7 @@
             "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
             "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "pascal-case": "^3.1.2",
                 "tslib": "^2.0.3"
@@ -3892,6 +4861,7 @@
             "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
             "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "browserslist": "^4.0.0",
                 "caniuse-lite": "^1.0.0",
@@ -3939,6 +4909,7 @@
             "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
             "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -4040,6 +5011,7 @@
             "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
             "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "source-map": "~0.6.0"
             },
@@ -4052,6 +5024,7 @@
             "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
             "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "string-width": "^4.2.0"
             },
@@ -4081,6 +5054,7 @@
             "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
             "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "is-plain-object": "^2.0.4",
                 "kind-of": "^6.0.2",
@@ -4095,6 +5069,7 @@
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "isobject": "^3.0.1"
             },
@@ -4127,13 +5102,15 @@
             "version": "2.9.3",
             "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
             "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/colorette": {
             "version": "2.0.20",
             "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
             "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
@@ -4152,6 +5129,7 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
             "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -4160,13 +5138,15 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
             "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/compressible": {
             "version": "2.0.18",
             "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
             "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "mime-db": ">= 1.43.0 < 2"
             },
@@ -4179,6 +5159,7 @@
             "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
             "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "accepts": "~1.3.5",
                 "bytes": "3.0.0",
@@ -4197,6 +5178,7 @@
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
             "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.8"
             }
@@ -4205,13 +5187,15 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/concat": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/concat/-/concat-1.0.3.tgz",
             "integrity": "sha512-f/ZaH1aLe64qHgTILdldbvyfGiGF4uzeo9IuXUloIOLQzFmIPloy9QbZadNsuVv0j5qbKQvQb/H/UYf2UsKTpw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "commander": "^2.9.0"
             },
@@ -4231,7 +5215,8 @@
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/connect": {
             "version": "3.6.6",
@@ -4261,7 +5246,8 @@
             "version": "2.15.3",
             "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
             "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/console-browserify": {
             "version": "1.2.0",
@@ -4280,6 +5266,7 @@
             "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
             "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "safe-buffer": "5.2.1"
             },
@@ -4292,6 +5279,7 @@
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
             "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -4300,7 +5288,8 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/cookie": {
             "version": "0.4.2",
@@ -4315,13 +5304,15 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
             "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/core-js-compat": {
             "version": "3.35.1",
             "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.35.1.tgz",
             "integrity": "sha512-sftHa5qUJY3rs9Zht1WEnmkvXputCyDBczPnr7QDgL8n3qrF3CMXY4VPSYtOLLiOUJcah2WNXREd48iOl6mQIw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "browserslist": "^4.22.2"
             },
@@ -4334,7 +5325,8 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/cors": {
             "version": "2.8.5",
@@ -4354,6 +5346,7 @@
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
             "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/parse-json": "^4.0.0",
                 "import-fresh": "^3.2.1",
@@ -4408,6 +5401,12 @@
                 "sha.js": "^2.4.8"
             }
         },
+        "node_modules/create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true
+        },
         "node_modules/cross-env": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -4444,6 +5443,7 @@
             "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
             "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -4475,6 +5475,7 @@
             "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
             "integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": "^10 || ^12 || >=14"
             },
@@ -4487,6 +5488,7 @@
             "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.7.tgz",
             "integrity": "sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "icss-utils": "^5.1.0",
                 "loader-utils": "^2.0.0",
@@ -4515,6 +5517,7 @@
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
             "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
@@ -4533,6 +5536,7 @@
             "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
             "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "boolbase": "^1.0.0",
                 "css-what": "^6.0.1",
@@ -4549,6 +5553,7 @@
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
             "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "domelementtype": "^2.2.0"
             },
@@ -4564,6 +5569,7 @@
             "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
             "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "mdn-data": "2.0.14",
                 "source-map": "^0.6.1"
@@ -4577,6 +5583,7 @@
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
             "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 6"
             },
@@ -4600,6 +5607,7 @@
             "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.15.tgz",
             "integrity": "sha512-j+BKgDcLDQA+eDifLx0EO4XSA56b7uut3BQFH+wbSaSTuGLuiyTa/wbRYthUXX8LC9mLg+WWKe8h+qJuwTAbHw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "cssnano-preset-default": "^5.2.14",
                 "lilconfig": "^2.0.3",
@@ -4621,6 +5629,7 @@
             "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.14.tgz",
             "integrity": "sha512-t0SFesj/ZV2OTylqQVOrFgEh5uanxbO6ZAdeCrNsUQ6fVuXwYTxJPNAGvGTxHbD68ldIJNec7PyYZDBrfDQ+6A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "css-declaration-sorter": "^6.3.1",
                 "cssnano-utils": "^3.1.0",
@@ -4664,6 +5673,7 @@
             "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
             "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": "^10 || ^12 || >=14.0"
             },
@@ -4676,12 +5686,20 @@
             "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
             "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "css-tree": "^1.1.2"
             },
             "engines": {
                 "node": ">=8.0.0"
             }
+        },
+        "node_modules/csstype": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "dev": true,
+            "peer": true
         },
         "node_modules/debug": {
             "version": "2.6.9",
@@ -4705,6 +5723,7 @@
             "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
             "integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "execa": "^5.0.0"
             },
@@ -4730,6 +5749,7 @@
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
             "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4789,7 +5809,8 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
             "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/dev-ip": {
             "version": "1.0.1",
@@ -4830,6 +5851,7 @@
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
             "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "path-type": "^4.0.0"
             },
@@ -4847,6 +5869,7 @@
             "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
             "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@leichtgewicht/ip-codec": "^2.0.1"
             },
@@ -4859,6 +5882,7 @@
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
             "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "domelementtype": "^2.0.1",
                 "domhandler": "^4.2.0",
@@ -4873,6 +5897,7 @@
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
             "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "domelementtype": "^2.2.0"
             },
@@ -4888,6 +5913,7 @@
             "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
             "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.4",
                 "npm": ">=1.2"
@@ -4909,6 +5935,7 @@
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
             "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "domelementtype": "^2.0.1"
             },
@@ -4924,6 +5951,7 @@
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
             "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "dom-serializer": "^1.0.1",
                 "domelementtype": "^2.2.0",
@@ -4938,6 +5966,7 @@
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
             "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "domelementtype": "^2.2.0"
             },
@@ -4953,6 +5982,7 @@
             "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
             "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "no-case": "^3.0.4",
                 "tslib": "^2.0.3"
@@ -4963,6 +5993,7 @@
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
             "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -4971,7 +6002,8 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
             "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
@@ -5164,6 +6196,7 @@
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
             "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
             "dev": true,
+            "peer": true,
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
@@ -5173,6 +6206,7 @@
             "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.11.0.tgz",
             "integrity": "sha512-G9/6xF1FPbIw0TtalAMaVPpiq2aDEuKLXM314jPVAO9r2fo2a4BLqMNkmRS7O/xPPZ+COAhGIz3ETvHEV3eUcg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "envinfo": "dist/cli.js"
             },
@@ -5185,6 +6219,7 @@
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "is-arrayish": "^0.2.1"
             }
@@ -5199,6 +6234,44 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
             "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw=="
+        },
+        "node_modules/esbuild": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
+            "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.19.12",
+                "@esbuild/android-arm": "0.19.12",
+                "@esbuild/android-arm64": "0.19.12",
+                "@esbuild/android-x64": "0.19.12",
+                "@esbuild/darwin-arm64": "0.19.12",
+                "@esbuild/darwin-x64": "0.19.12",
+                "@esbuild/freebsd-arm64": "0.19.12",
+                "@esbuild/freebsd-x64": "0.19.12",
+                "@esbuild/linux-arm": "0.19.12",
+                "@esbuild/linux-arm64": "0.19.12",
+                "@esbuild/linux-ia32": "0.19.12",
+                "@esbuild/linux-loong64": "0.19.12",
+                "@esbuild/linux-mips64el": "0.19.12",
+                "@esbuild/linux-ppc64": "0.19.12",
+                "@esbuild/linux-riscv64": "0.19.12",
+                "@esbuild/linux-s390x": "0.19.12",
+                "@esbuild/linux-x64": "0.19.12",
+                "@esbuild/netbsd-x64": "0.19.12",
+                "@esbuild/openbsd-x64": "0.19.12",
+                "@esbuild/sunos-x64": "0.19.12",
+                "@esbuild/win32-arm64": "0.19.12",
+                "@esbuild/win32-ia32": "0.19.12",
+                "@esbuild/win32-x64": "0.19.12"
+            }
         },
         "node_modules/escalade": {
             "version": "3.1.1",
@@ -5268,11 +6341,18 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -5316,6 +6396,7 @@
             "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
             "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "cross-spawn": "^7.0.3",
                 "get-stream": "^6.0.0",
@@ -5339,6 +6420,7 @@
             "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
             "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
@@ -5381,6 +6463,7 @@
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
             "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -5390,6 +6473,7 @@
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
             "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.8",
                 "npm": "1.2.8000 || >= 1.4.16"
@@ -5400,6 +6484,7 @@
             "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
             "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "debug": "2.6.9",
                 "encodeurl": "~1.0.2",
@@ -5418,6 +6503,7 @@
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
             "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "mime": "cli.js"
             },
@@ -5429,13 +6515,15 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/express/node_modules/on-finished": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
             "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ee-first": "1.1.1"
             },
@@ -5448,6 +6536,7 @@
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
             "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "side-channel": "^1.0.4"
             },
@@ -5463,6 +6552,7 @@
             "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
             "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "debug": "2.6.9",
                 "depd": "2.0.0",
@@ -5487,6 +6577,7 @@
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
             "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
@@ -5502,6 +6593,7 @@
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
             "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.8"
             }
@@ -5538,6 +6630,7 @@
             "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
             "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 4.9.1"
             }
@@ -5555,6 +6648,7 @@
             "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
             "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "websocket-driver": ">=0.5.1"
             },
@@ -5575,6 +6669,7 @@
             "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
             "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "loader-utils": "^2.0.0",
                 "schema-utils": "^3.0.0"
@@ -5595,6 +6690,7 @@
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
             "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
@@ -5613,6 +6709,7 @@
             "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.2.tgz",
             "integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5651,6 +6748,7 @@
             "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
             "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "commondir": "^1.0.1",
                 "make-dir": "^3.0.2",
@@ -5668,6 +6766,7 @@
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
             "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
@@ -5689,6 +6788,7 @@
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
             "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "flat": "cli.js"
             }
@@ -5766,6 +6866,7 @@
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
             "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -5806,13 +6907,15 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.5.tgz",
             "integrity": "sha512-8uMbBjrhzW76TYgEV27Y5E//W2f/lTFmx78P2w19FZSxarhI/798APGQyuGCwmkNxgwGRhrLfvWyLBvNtuOmew==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
@@ -5845,6 +6948,7 @@
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
             "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -5877,6 +6981,7 @@
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -5889,6 +6994,7 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -5926,6 +7032,7 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -5935,6 +7042,7 @@
             "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
             "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/glob": "^7.1.1",
                 "array-union": "^2.1.0",
@@ -5970,7 +7078,8 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
             "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/hamburgers": {
             "version": "1.2.1",
@@ -5981,7 +7090,8 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
             "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
@@ -6071,7 +7181,8 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
             "integrity": "sha512-fUs4B4L+mlt8/XAtSOGMUO1TXmAelItBPtJG7CyHJfYTdDjwisntGO2JQz7oUsatOY9o68+57eziUVNw/mRHmA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/hash.js": {
             "version": "1.1.7",
@@ -6099,6 +7210,7 @@
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "he": "bin/he"
             }
@@ -6119,6 +7231,7 @@
             "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
             "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "inherits": "^2.0.1",
                 "obuf": "^1.0.0",
@@ -6140,13 +7253,15 @@
                     "type": "patreon",
                     "url": "https://patreon.com/mdevils"
                 }
-            ]
+            ],
+            "peer": true
         },
         "node_modules/html-loader": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-1.3.2.tgz",
             "integrity": "sha512-DEkUwSd0sijK5PF3kRWspYi56XP7bTNkyg5YWSzBdjaSDmvCufep5c4Vpb3PBf6lUL0YPtLwBfy9fL0t5hBAGA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "html-minifier-terser": "^5.1.1",
                 "htmlparser2": "^4.1.0",
@@ -6169,6 +7284,7 @@
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
             "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
@@ -6187,6 +7303,7 @@
             "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
             "integrity": "sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "camel-case": "^4.1.1",
                 "clean-css": "^4.2.3",
@@ -6208,6 +7325,7 @@
             "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
             "integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "source-map": "~0.6.0"
             },
@@ -6220,6 +7338,7 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
             "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -6229,6 +7348,7 @@
             "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
             "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "commander": "^2.20.0",
                 "source-map": "~0.6.1",
@@ -6245,13 +7365,15 @@
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/htmlparser2": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
             "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "domelementtype": "^2.0.1",
                 "domhandler": "^3.0.0",
@@ -6263,7 +7385,8 @@
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
             "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/http-errors": {
             "version": "2.0.0",
@@ -6294,7 +7417,8 @@
             "version": "0.5.8",
             "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
             "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/http-proxy": {
             "version": "1.18.1",
@@ -6315,6 +7439,7 @@
             "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
             "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/http-proxy": "^1.17.8",
                 "http-proxy": "^1.18.1",
@@ -6345,6 +7470,7 @@
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10.17.0"
             }
@@ -6375,6 +7501,7 @@
             "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
             "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": "^10 || ^12 || >= 14"
             },
@@ -6406,6 +7533,7 @@
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
             "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -6415,6 +7543,7 @@
             "resolved": "https://registry.npmjs.org/imagemin/-/imagemin-7.0.1.tgz",
             "integrity": "sha512-33AmZ+xjZhg2JMCe+vDf6a9mzWukE7l+wAtesjE7KyteqqKjzxv7aVQeWnul1Ve26mWvEQqyPwl0OctNBfSR9w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "file-type": "^12.0.0",
                 "globby": "^10.0.0",
@@ -6433,6 +7562,7 @@
             "resolved": "https://registry.npmjs.org/img-loader/-/img-loader-4.0.0.tgz",
             "integrity": "sha512-UwRcPQdwdOyEHyCxe1V9s9YFwInwEWCpoO+kJGfIqDrBDqA8jZUsEZTxQ0JteNPGw/Gupmwesk2OhLTcnw6tnQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "loader-utils": "^1.1.0"
             },
@@ -6448,6 +7578,7 @@
             "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
             "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "minimist": "^1.2.0"
             },
@@ -6460,6 +7591,7 @@
             "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
             "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
@@ -6483,6 +7615,7 @@
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
             "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -6499,6 +7632,7 @@
             "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
             "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "pkg-dir": "^4.2.0",
                 "resolve-cwd": "^3.0.0"
@@ -6523,6 +7657,7 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -6538,6 +7673,7 @@
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
             "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.10"
             }
@@ -6547,6 +7683,7 @@
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
             "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -6570,7 +7707,8 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
@@ -6587,7 +7725,8 @@
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/is-callable": {
             "version": "1.2.7",
@@ -6616,6 +7755,7 @@
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
             "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "is-docker": "cli.js"
             },
@@ -6667,6 +7807,22 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-nan": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+            "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -6689,6 +7845,7 @@
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
             "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -6709,6 +7866,7 @@
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -6754,8 +7912,18 @@
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
             "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/isomorphic-timers-promises": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz",
+            "integrity": "sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/jackspeak": {
@@ -6845,13 +8013,15 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/jsesc": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
             "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -6897,6 +8067,7 @@
             "resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
             "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -6906,6 +8077,7 @@
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6924,6 +8096,7 @@
             "resolved": "https://registry.npmjs.org/laravel-mix/-/laravel-mix-6.0.49.tgz",
             "integrity": "sha512-bBMFpFjp26XfijPvY5y9zGKud7VqlyOE0OWUcPo3vTBY5asw8LTjafAbee1dhfLz6PWNqDziz69CP78ELSpfKw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.15.8",
                 "@babel/plugin-proposal-object-rest-spread": "^7.15.6",
@@ -6999,6 +8172,7 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
             "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
@@ -7013,6 +8187,7 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
             "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "universalify": "^2.0.0"
             },
@@ -7025,8 +8200,28 @@
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
             "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/laravel-vite-plugin": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-1.0.1.tgz",
+            "integrity": "sha512-laLEZUnSskIDZtLb2FNRdcjsRUhh1VOVvapbVGVTeaBPJTCF/b6gbPiX2dZdcH1RKoOE0an7L+2gnInk6K33Zw==",
+            "dev": true,
+            "dependencies": {
+                "picocolors": "^1.0.0",
+                "vite-plugin-full-reload": "^1.1.0"
+            },
+            "bin": {
+                "clean-orphaned-assets": "bin/clean.js"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "peerDependencies": {
+                "vite": "^5.0.0"
             }
         },
         "node_modules/launch-editor": {
@@ -7034,6 +8229,7 @@
             "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.1.tgz",
             "integrity": "sha512-eB/uXmFVpY4zezmGp5XtU21kwo7GBbKB+EQ+UZeWtGb9yAM5xt/Evk+lYH3eRNAtId+ej4u7TYPFZ07w4s7rRw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "picocolors": "^1.0.0",
                 "shell-quote": "^1.8.1"
@@ -7174,6 +8370,7 @@
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
             "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "p-locate": "^4.1.0"
             },
@@ -7200,7 +8397,8 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/lodash.isfinite": {
             "version": "3.3.2",
@@ -7217,7 +8415,8 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
@@ -7228,13 +8427,15 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
             "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/lower-case": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
             "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.0.3"
             }
@@ -7244,8 +8445,21 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
             "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.7",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.7.tgz",
+            "integrity": "sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.4.15"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/make-dir": {
@@ -7253,6 +8467,7 @@
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
             "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "semver": "^6.0.0"
             },
@@ -7268,6 +8483,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -7277,6 +8493,7 @@
             "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
             "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "charenc": "0.0.2",
                 "crypt": "0.0.2",
@@ -7298,13 +8515,15 @@
             "version": "2.0.14",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
             "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -7314,6 +8533,7 @@
             "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
             "integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fs-monkey": "^1.0.4"
             },
@@ -7325,7 +8545,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
             "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
@@ -7346,6 +8567,7 @@
             "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
             "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -7416,6 +8638,7 @@
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -7425,6 +8648,7 @@
             "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.2.tgz",
             "integrity": "sha512-WhDvO3SjGm40oV5y26GjMJYjd2UMqrLAGKy5YS2/3QKJy2F7jgynuHTir/tgUUOiNQu5saXHdc8reo7YuhhT4Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "loader-utils": "^2.0.0",
                 "schema-utils": "^3.0.0",
@@ -7446,6 +8670,7 @@
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
             "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
@@ -7554,6 +8779,7 @@
             "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
             "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "dns-packet": "^5.2.2",
                 "thunky": "^1.0.2"
@@ -7620,6 +8846,7 @@
             "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
             "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "lower-case": "^2.0.2",
                 "tslib": "^2.0.3"
@@ -7630,6 +8857,7 @@
             "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
             "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 6.13.0"
             }
@@ -7639,6 +8867,7 @@
             "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
             "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "assert": "^1.1.1",
                 "browserify-zlib": "^0.2.0",
@@ -7670,6 +8899,7 @@
             "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-9.0.1.tgz",
             "integrity": "sha512-fPNFIp2hF/Dq7qLDzSg4vZ0J4e9v60gJR+Qx7RbjbWqzPDdEqeVpEx5CFeDAELIl+A/woaaNn1fQ5nEVerMxJg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "growly": "^1.3.0",
                 "is-wsl": "^2.2.0",
@@ -7684,6 +8914,7 @@
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
             "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "is-docker": "^2.0.0"
             },
@@ -7696,6 +8927,7 @@
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -7704,6 +8936,227 @@
             "version": "2.0.14",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
             "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+        },
+        "node_modules/node-stdlib-browser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.2.0.tgz",
+            "integrity": "sha512-VSjFxUhRhkyed8AtLwSCkMrJRfQ3e2lGtG3sP6FEgaLKBBbxM/dLfjRe1+iLhjvyLFW3tBQ8+c0pcOtXGbAZJg==",
+            "dev": true,
+            "dependencies": {
+                "assert": "^2.0.0",
+                "browser-resolve": "^2.0.0",
+                "browserify-zlib": "^0.2.0",
+                "buffer": "^5.7.1",
+                "console-browserify": "^1.1.0",
+                "constants-browserify": "^1.0.0",
+                "create-require": "^1.1.1",
+                "crypto-browserify": "^3.11.0",
+                "domain-browser": "^4.22.0",
+                "events": "^3.0.0",
+                "https-browserify": "^1.0.0",
+                "isomorphic-timers-promises": "^1.0.1",
+                "os-browserify": "^0.3.0",
+                "path-browserify": "^1.0.1",
+                "pkg-dir": "^5.0.0",
+                "process": "^0.11.10",
+                "punycode": "^1.4.1",
+                "querystring-es3": "^0.2.1",
+                "readable-stream": "^3.6.0",
+                "stream-browserify": "^3.0.0",
+                "stream-http": "^3.2.0",
+                "string_decoder": "^1.0.0",
+                "timers-browserify": "^2.0.4",
+                "tty-browserify": "0.0.1",
+                "url": "^0.11.0",
+                "util": "^0.12.4",
+                "vm-browserify": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/node-stdlib-browser/node_modules/assert": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+            "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "is-nan": "^1.3.2",
+                "object-is": "^1.1.5",
+                "object.assign": "^4.1.4",
+                "util": "^0.12.5"
+            }
+        },
+        "node_modules/node-stdlib-browser/node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "node_modules/node-stdlib-browser/node_modules/domain-browser": {
+            "version": "4.23.0",
+            "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.23.0.tgz",
+            "integrity": "sha512-ArzcM/II1wCCujdCNyQjXrAFwS4mrLh4C7DZWlaI8mdh7h3BfKdNd3bKXITfl2PT9FtfQqaGvhi1vPRQPimjGA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://bevry.me/fund"
+            }
+        },
+        "node_modules/node-stdlib-browser/node_modules/find-up": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/node-stdlib-browser/node_modules/locate-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
+            "dependencies": {
+                "p-locate": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/node-stdlib-browser/node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/node-stdlib-browser/node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/node-stdlib-browser/node_modules/path-browserify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+            "dev": true
+        },
+        "node_modules/node-stdlib-browser/node_modules/pkg-dir": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+            "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+            "dev": true,
+            "dependencies": {
+                "find-up": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/node-stdlib-browser/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "dev": true,
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/node-stdlib-browser/node_modules/stream-browserify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+            "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+            "dev": true,
+            "dependencies": {
+                "inherits": "~2.0.4",
+                "readable-stream": "^3.5.0"
+            }
+        },
+        "node_modules/node-stdlib-browser/node_modules/stream-http": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
+            "integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
+            "dev": true,
+            "dependencies": {
+                "builtin-status-codes": "^3.0.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.6.0",
+                "xtend": "^4.0.2"
+            }
+        },
+        "node_modules/node-stdlib-browser/node_modules/tty-browserify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+            "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+            "dev": true
+        },
+        "node_modules/node-stdlib-browser/node_modules/util": {
+            "version": "0.12.5",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+            "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+            "dev": true,
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "is-arguments": "^1.0.4",
+                "is-generator-function": "^1.0.7",
+                "is-typed-array": "^1.1.3",
+                "which-typed-array": "^1.1.2"
+            }
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
@@ -7726,6 +9179,7 @@
             "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
             "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -7743,6 +9197,7 @@
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "path-key": "^3.0.0"
             },
@@ -7755,6 +9210,7 @@
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
             "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "boolbase": "^1.0.0"
             },
@@ -7783,6 +9239,22 @@
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
             "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
             "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-is": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+            "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -7823,7 +9295,8 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
             "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/on-finished": {
             "version": "2.3.0",
@@ -7842,6 +9315,7 @@
             "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
             "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.8"
             }
@@ -7851,6 +9325,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -7860,6 +9335,7 @@
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "mimic-fn": "^2.1.0"
             },
@@ -7875,6 +9351,7 @@
             "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
             "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "define-lazy-prop": "^2.0.0",
                 "is-docker": "^2.1.1",
@@ -7892,6 +9369,7 @@
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
             "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "is-docker": "^2.0.0"
             },
@@ -7928,6 +9406,7 @@
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
             "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "p-try": "^2.0.0"
             },
@@ -7943,6 +9422,7 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
             "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "p-limit": "^2.2.0"
             },
@@ -7955,6 +9435,7 @@
             "resolved": "https://registry.npmjs.org/p-pipe/-/p-pipe-3.1.0.tgz",
             "integrity": "sha512-08pj8ATpzMR0Y80x50yJHn37NF6vjrqHutASaX5LiH5npS9XPvrUmscd9MF5R4fuYRHOxQR1FfMIlF7AzwoPqw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -7967,6 +9448,7 @@
             "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
             "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/retry": "0.12.0",
                 "retry": "^0.13.1"
@@ -7980,6 +9462,7 @@
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -7995,6 +9478,7 @@
             "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
             "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "dot-case": "^3.0.4",
                 "tslib": "^2.0.3"
@@ -8005,6 +9489,7 @@
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -8030,6 +9515,7 @@
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
             "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
@@ -8062,6 +9548,7 @@
             "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
             "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "no-case": "^3.0.4",
                 "tslib": "^2.0.3"
@@ -8071,7 +9558,8 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
             "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
@@ -8087,6 +9575,7 @@
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8131,13 +9620,15 @@
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
             "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/path-type": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -8200,6 +9691,7 @@
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
             "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "find-up": "^4.0.0"
             },
@@ -8233,9 +9725,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.33",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
-            "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
+            "version": "8.4.35",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+            "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -8264,6 +9756,7 @@
             "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
             "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "postcss-selector-parser": "^6.0.9",
                 "postcss-value-parser": "^4.2.0"
@@ -8277,6 +9770,7 @@
             "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.1.tgz",
             "integrity": "sha512-UsWQG0AqTFQmpBegeLLc1+c3jIqBNB0zlDGRWR+dQ3pRKJL1oeMzyqmH3o2PIfn9MBdNrVPWhDbT769LxCTLJQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "browserslist": "^4.21.4",
                 "caniuse-api": "^3.0.0",
@@ -8295,6 +9789,7 @@
             "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.3.tgz",
             "integrity": "sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "browserslist": "^4.21.4",
                 "postcss-value-parser": "^4.2.0"
@@ -8311,6 +9806,7 @@
             "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
             "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": "^10 || ^12 || >=14.0"
             },
@@ -8323,6 +9819,7 @@
             "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
             "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": "^10 || ^12 || >=14.0"
             },
@@ -8335,6 +9832,7 @@
             "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
             "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": "^10 || ^12 || >=14.0"
             },
@@ -8347,6 +9845,7 @@
             "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
             "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": "^10 || ^12 || >=14.0"
             },
@@ -8393,6 +9892,7 @@
             "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
             "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "lilconfig": "^2.0.5",
                 "yaml": "^1.10.2"
@@ -8422,6 +9922,7 @@
             "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.1.tgz",
             "integrity": "sha512-WbbYpmAaKcux/P66bZ40bpWsBucjx/TTgVVzRZ9yUO8yQfVBlameJ0ZGVaPfH64hNSBh63a+ICP5nqOpBA0w+Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "cosmiconfig": "^7.0.0",
                 "klona": "^2.0.5",
@@ -8444,6 +9945,7 @@
             "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.7.tgz",
             "integrity": "sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0",
                 "stylehacks": "^5.1.1"
@@ -8460,6 +9962,7 @@
             "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.4.tgz",
             "integrity": "sha512-0R2IuYpgU93y9lhVbO/OylTtKMVcHb67zjWIfCiKR9rWL3GUk1677LAqD/BcHizukdZEjT8Ru3oHRoAYoJy44g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "browserslist": "^4.21.4",
                 "caniuse-api": "^3.0.0",
@@ -8478,6 +9981,7 @@
             "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.1.0.tgz",
             "integrity": "sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
@@ -8493,6 +9997,7 @@
             "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.1.1.tgz",
             "integrity": "sha512-VGvXMTpCEo4qHTNSa9A0a3D+dxGFZCYwR6Jokk+/3oB6flu2/PnPXAh2x7x52EkY5xlIHLm+Le8tJxe/7TNhzw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "colord": "^2.9.1",
                 "cssnano-utils": "^3.1.0",
@@ -8510,6 +10015,7 @@
             "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.4.tgz",
             "integrity": "sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "browserslist": "^4.21.4",
                 "cssnano-utils": "^3.1.0",
@@ -8527,6 +10033,7 @@
             "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.1.tgz",
             "integrity": "sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "postcss-selector-parser": "^6.0.5"
             },
@@ -8542,6 +10049,7 @@
             "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
             "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": "^10 || ^12 || >= 14"
             },
@@ -8554,6 +10062,7 @@
             "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.4.tgz",
             "integrity": "sha512-L4QzMnOdVwRm1Qb8m4x8jsZzKAaPAgrUF1r/hjDR2Xj7R+8Zsf97jAlSQzWtKx5YNiNGN8QxmPFIc/sh+RQl+Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "icss-utils": "^5.0.0",
                 "postcss-selector-parser": "^6.0.2",
@@ -8571,6 +10080,7 @@
             "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.1.1.tgz",
             "integrity": "sha512-uZgqzdTleelWjzJY+Fhti6F3C9iF1JR/dODLs/JDefozYcKTBCdD8BIl6nNPbTbcLnGrk56hzwZC2DaGNvYjzA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "postcss-selector-parser": "^6.0.4"
             },
@@ -8586,6 +10096,7 @@
             "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
             "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "icss-utils": "^5.0.0"
             },
@@ -8631,6 +10142,7 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
             "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": "^10 || ^12 || >=14.0"
             },
@@ -8643,6 +10155,7 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.1.0.tgz",
             "integrity": "sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
@@ -8658,6 +10171,7 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.1.tgz",
             "integrity": "sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
@@ -8673,6 +10187,7 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.1.tgz",
             "integrity": "sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
@@ -8688,6 +10203,7 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.1.0.tgz",
             "integrity": "sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
@@ -8703,6 +10219,7 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.1.0.tgz",
             "integrity": "sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
@@ -8718,6 +10235,7 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.1.tgz",
             "integrity": "sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "browserslist": "^4.21.4",
                 "postcss-value-parser": "^4.2.0"
@@ -8734,6 +10252,7 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.1.0.tgz",
             "integrity": "sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "normalize-url": "^6.0.1",
                 "postcss-value-parser": "^4.2.0"
@@ -8750,6 +10269,7 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.1.1.tgz",
             "integrity": "sha512-83ZJ4t3NUDETIHTa3uEg6asWjSBYL5EdkVB0sDncx9ERzOKBVJIUeDO9RyA9Zwtig8El1d79HBp0JEi8wvGQnA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
@@ -8765,6 +10285,7 @@
             "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.3.tgz",
             "integrity": "sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "cssnano-utils": "^3.1.0",
                 "postcss-value-parser": "^4.2.0"
@@ -8781,6 +10302,7 @@
             "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.2.tgz",
             "integrity": "sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "browserslist": "^4.21.4",
                 "caniuse-api": "^3.0.0"
@@ -8797,6 +10319,7 @@
             "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.1.0.tgz",
             "integrity": "sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
@@ -8824,6 +10347,7 @@
             "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
             "integrity": "sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0",
                 "svgo": "^2.7.0"
@@ -8840,6 +10364,7 @@
             "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.1.tgz",
             "integrity": "sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "postcss-selector-parser": "^6.0.5"
             },
@@ -8869,6 +10394,7 @@
             "resolved": "https://registry.npmjs.org/pretty-time/-/pretty-time-1.1.0.tgz",
             "integrity": "sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -8886,7 +10412,8 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/progressbar.js": {
             "version": "1.1.1",
@@ -8915,6 +10442,7 @@
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
             "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "forwarded": "0.2.0",
                 "ipaddr.js": "1.9.1"
@@ -8928,6 +10456,7 @@
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
             "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.10"
             }
@@ -9072,6 +10601,7 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
             "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -9086,13 +10616,15 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/readable-stream/node_modules/string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
@@ -9113,6 +10645,7 @@
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
             "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "resolve": "^1.9.0"
             },
@@ -9124,13 +10657,15 @@
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
             "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/regenerate-unicode-properties": {
             "version": "10.1.1",
             "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.1.tgz",
             "integrity": "sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "regenerate": "^1.4.2"
             },
@@ -9142,13 +10677,15 @@
             "version": "0.14.1",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
             "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/regenerator-transform": {
             "version": "0.15.2",
             "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
             "integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.8.4"
             }
@@ -9164,6 +10701,7 @@
             "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.2.tgz",
             "integrity": "sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/regjsgen": "^0.8.0",
                 "regenerate": "^1.4.2",
@@ -9181,6 +10719,7 @@
             "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
             "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "jsesc": "~0.5.0"
             },
@@ -9193,6 +10732,7 @@
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
             "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             }
@@ -9202,6 +10742,7 @@
             "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
             "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.10"
             }
@@ -9211,6 +10752,7 @@
             "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
             "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.10"
             }
@@ -9229,6 +10771,7 @@
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9260,6 +10803,7 @@
             "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
             "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "resolve-from": "^5.0.0"
             },
@@ -9272,6 +10816,7 @@
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -9281,6 +10826,7 @@
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -9325,6 +10871,7 @@
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
             "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -9354,6 +10901,38 @@
             "dependencies": {
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1"
+            }
+        },
+        "node_modules/rollup": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.6.tgz",
+            "integrity": "sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "1.0.5"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.9.6",
+                "@rollup/rollup-android-arm64": "4.9.6",
+                "@rollup/rollup-darwin-arm64": "4.9.6",
+                "@rollup/rollup-darwin-x64": "4.9.6",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.9.6",
+                "@rollup/rollup-linux-arm64-gnu": "4.9.6",
+                "@rollup/rollup-linux-arm64-musl": "4.9.6",
+                "@rollup/rollup-linux-riscv64-gnu": "4.9.6",
+                "@rollup/rollup-linux-x64-gnu": "4.9.6",
+                "@rollup/rollup-linux-x64-musl": "4.9.6",
+                "@rollup/rollup-win32-arm64-msvc": "4.9.6",
+                "@rollup/rollup-win32-ia32-msvc": "4.9.6",
+                "@rollup/rollup-win32-x64-msvc": "4.9.6",
+                "fsevents": "~2.3.2"
             }
         },
         "node_modules/run-parallel": {
@@ -9563,6 +11142,7 @@
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
             "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.5",
                 "ajv": "^6.12.4",
@@ -9580,7 +11160,8 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
             "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/select2": {
             "version": "4.0.13",
@@ -9597,6 +11178,7 @@
             "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
             "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/node-forge": "^1.3.0",
                 "node-forge": "^1"
@@ -9610,6 +11192,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
             "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -9625,6 +11208,7 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -9636,7 +11220,8 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/send": {
             "version": "0.16.2",
@@ -9932,6 +11517,7 @@
             "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
             "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "kind-of": "^6.0.2"
             },
@@ -9963,6 +11549,7 @@
             "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
             "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
             "dev": true,
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -9971,7 +11558,8 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
             "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/shifty": {
             "version": "2.20.4",
@@ -9999,7 +11587,8 @@
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/simplebar": {
             "version": "6.2.5",
@@ -10026,6 +11615,7 @@
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -10159,6 +11749,7 @@
             "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
             "integrity": "sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "faye-websocket": "^0.11.3",
                 "uuid": "^8.3.2",
@@ -10170,6 +11761,7 @@
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -10193,7 +11785,8 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
             "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/source-map": {
             "version": "0.6.1",
@@ -10227,6 +11820,7 @@
             "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
             "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "debug": "^4.1.0",
                 "handle-thing": "^2.0.0",
@@ -10243,6 +11837,7 @@
             "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
             "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "debug": "^4.1.0",
                 "detect-node": "^2.0.4",
@@ -10257,6 +11852,7 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -10273,13 +11869,15 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/spdy-transport/node_modules/readable-stream": {
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
             "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -10294,6 +11892,7 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -10310,14 +11909,16 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/stable": {
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
             "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
             "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/statuses": {
             "version": "1.3.1",
@@ -10332,13 +11933,15 @@
             "version": "3.7.0",
             "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
             "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/stream-browserify": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
             "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "inherits": "~2.0.1",
                 "readable-stream": "^2.0.2"
@@ -10349,6 +11952,7 @@
             "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
             "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "builtin-status-codes": "^3.0.0",
                 "inherits": "^2.0.1",
@@ -10448,6 +12052,7 @@
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -10457,6 +12062,7 @@
             "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-2.0.0.tgz",
             "integrity": "sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "loader-utils": "^2.0.0",
                 "schema-utils": "^3.0.0"
@@ -10477,6 +12083,7 @@
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
             "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
@@ -10495,6 +12102,7 @@
             "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
             "integrity": "sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "browserslist": "^4.21.4",
                 "postcss-selector-parser": "^6.0.4"
@@ -10606,6 +12214,7 @@
             "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
             "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@trysound/sax": "0.2.0",
                 "commander": "^7.2.0",
@@ -10856,7 +12465,8 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
             "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/timers-browserify": {
             "version": "2.0.12",
@@ -10883,13 +12493,15 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
             "integrity": "sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/to-fast-properties": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
             "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -10931,19 +12543,22 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/tty-browserify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
             "integrity": "sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/type-is": {
             "version": "1.6.18",
             "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
             "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "media-typer": "0.3.0",
                 "mime-types": "~2.1.24"
@@ -10986,6 +12601,7 @@
             "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
             "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -10995,6 +12611,7 @@
             "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
             "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "unicode-canonical-property-names-ecmascript": "^2.0.0",
                 "unicode-property-aliases-ecmascript": "^2.0.0"
@@ -11008,6 +12625,7 @@
             "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz",
             "integrity": "sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -11017,6 +12635,7 @@
             "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
             "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -11101,6 +12720,7 @@
             "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
             "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "inherits": "2.0.3"
             }
@@ -11114,7 +12734,8 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/utils-merge": {
             "version": "1.0.1",
@@ -11142,17 +12763,174 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/vite": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.0.tgz",
+            "integrity": "sha512-STmSFzhY4ljuhz14bg9LkMTk3d98IO6DIArnTY6MeBwiD1Za2StcQtz7fzOUnRCqrHSD5+OS2reg4HOz1eoLnw==",
+            "dev": true,
+            "dependencies": {
+                "esbuild": "^0.19.3",
+                "postcss": "^8.4.35",
+                "rollup": "^4.2.0"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "less": "*",
+                "lightningcss": "^1.21.0",
+                "sass": "*",
+                "stylus": "*",
+                "sugarss": "*",
+                "terser": "^5.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-plugin-full-reload": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-full-reload/-/vite-plugin-full-reload-1.1.0.tgz",
+            "integrity": "sha512-3cObNDzX6DdfhD9E7kf6w2mNunFpD7drxyNgHLw+XwIYAgb+Xt16SEXo0Up4VH+TMf3n+DSVJZtW2POBGcBYAA==",
+            "dev": true,
+            "dependencies": {
+                "picocolors": "^1.0.0",
+                "picomatch": "^2.3.1"
+            }
+        },
+        "node_modules/vite-plugin-node-polyfills": {
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.19.0.tgz",
+            "integrity": "sha512-AhdVxAmVnd1doUlIRGUGV6ZRPfB9BvIwDF10oCOmL742IsvsFIAV4tSMxSfu5e0Px0QeJLgWVOSbtHIvblzqMw==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/plugin-inject": "^5.0.5",
+                "node-stdlib-browser": "^1.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/davidmyersdev"
+            },
+            "peerDependencies": {
+                "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
+            }
+        },
+        "node_modules/vite-plugin-static-copy": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-1.0.1.tgz",
+            "integrity": "sha512-3eGL4mdZoPJMDBT68pv/XKIHR4MgVolStIxxv1gIBP4R8TpHn9C9EnaU0hesqlseJ4ycLGUxckFTu/jpuJXQlA==",
+            "dev": true,
+            "dependencies": {
+                "chokidar": "^3.5.3",
+                "fast-glob": "^3.2.11",
+                "fs-extra": "^11.1.0",
+                "picocolors": "^1.0.0"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "peerDependencies": {
+                "vite": "^5.0.0"
+            }
+        },
+        "node_modules/vite-plugin-static-copy/node_modules/fs-extra": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
+            }
+        },
+        "node_modules/vite-plugin-static-copy/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/vite-plugin-static-copy/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
         "node_modules/vm-browserify": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
             "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
             "dev": true
         },
+        "node_modules/vue": {
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.17.tgz",
+            "integrity": "sha512-uRaVQNbCblmh8V5cEV0HzJoKHvzfKQPGr+ejfwDyCtsu+v/0F6iHesqvuO19iS4+dSENQcEEO1UXZirpDI+nkg==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-dom": "3.4.17",
+                "@vue/compiler-sfc": "3.4.17",
+                "@vue/runtime-dom": "3.4.17",
+                "@vue/server-renderer": "3.4.17",
+                "@vue/shared": "3.4.17"
+            },
+            "peerDependencies": {
+                "typescript": "*"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/vue-style-loader": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.3.tgz",
             "integrity": "sha512-sFuh0xfbtpRlKfm39ss/ikqs9AbKCoXZBpHeVZ8Tx650o0k0q/YCM7FRvigtxpACezfq6af+a7JeqVTWvncqDg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "hash-sum": "^1.0.2",
                 "loader-utils": "^1.0.2"
@@ -11163,6 +12941,7 @@
             "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
             "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "minimist": "^1.2.0"
             },
@@ -11175,6 +12954,7 @@
             "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
             "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
@@ -11183,6 +12963,13 @@
             "engines": {
                 "node": ">=4.0.0"
             }
+        },
+        "node_modules/vue/node_modules/@vue/shared": {
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.17.tgz",
+            "integrity": "sha512-BKloFjdOdVMnYVEKHzPHhJA5wW4iNzuUdEtj1F3phjHMSC269XcQl+L4cZ9EgbYyC/XuEYgn/ICV3VNmnDoH6g==",
+            "dev": true,
+            "peer": true
         },
         "node_modules/watchpack": {
             "version": "2.4.0",
@@ -11202,6 +12989,7 @@
             "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
             "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "minimalistic-assert": "^1.0.0"
             }
@@ -11263,6 +13051,7 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
             "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^1.2.0",
@@ -11310,6 +13099,7 @@
             "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
             "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "colorette": "^2.0.10",
                 "memfs": "^3.4.3",
@@ -11333,6 +13123,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
             "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -11349,6 +13140,7 @@
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
             "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3"
             },
@@ -11360,13 +13152,15 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/webpack-dev-middleware/node_modules/schema-utils": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
             "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.9",
                 "ajv": "^8.9.0",
@@ -11386,6 +13180,7 @@
             "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
             "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/bonjour": "^3.5.9",
                 "@types/connect-history-api-fallback": "^1.3.5",
@@ -11445,6 +13240,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
             "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -11461,6 +13257,7 @@
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
             "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3"
             },
@@ -11473,6 +13270,7 @@
             "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
             "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.8"
             }
@@ -11481,13 +13279,15 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/webpack-dev-server/node_modules/rimraf": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -11503,6 +13303,7 @@
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
             "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.9",
                 "ajv": "^8.9.0",
@@ -11522,6 +13323,7 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
             "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -11543,6 +13345,7 @@
             "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
             "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "clone-deep": "^4.0.1",
                 "flat": "^5.0.2",
@@ -11557,6 +13360,7 @@
             "resolved": "https://registry.npmjs.org/webpack-notifier/-/webpack-notifier-1.15.0.tgz",
             "integrity": "sha512-N2V8UMgRB5komdXQRavBsRpw0hPhJq2/SWNOGuhrXpIgRhcMexzkGQysUyGStHLV5hkUlgpRiF7IUXoBqyMmzQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "node-notifier": "^9.0.0",
                 "strip-ansi": "^6.0.0"
@@ -11575,6 +13379,7 @@
             "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
             "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "source-list-map": "^2.0.0",
                 "source-map": "~0.6.1"
@@ -11612,6 +13417,7 @@
             "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-5.0.2.tgz",
             "integrity": "sha512-BmFJo7veBDgQzfWXl/wwYXr/VFus0614qZ8i9znqcl9fnEdiVkdbi0TedLQ6xAK92HZHDJ0QmyQ0fmuZPAgCYQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "chalk": "^4.1.0",
                 "consola": "^2.15.3",
@@ -11630,6 +13436,7 @@
             "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
             "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "http-parser-js": ">=0.5.1",
                 "safe-buffer": ">=5.1.0",
@@ -11644,6 +13451,7 @@
             "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
             "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.8.0"
             }
@@ -11684,7 +13492,8 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
             "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
@@ -11724,7 +13533,8 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/ws": {
             "version": "8.11.0",
@@ -11798,13 +13608,15 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/yaml": {
             "version": "1.10.2",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -11834,6 +13646,18 @@
             "dev": true,
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,21 +1,20 @@
 {
     "private": true,
+    "type": "module",
     "scripts": {
-        "development": "mix",
-        "watch": "mix watch",
-        "watch-poll": "mix watch -- --watch-options-poll=1000",
-        "hot": "mix watch --hot",
-        "production": "mix --production",
-        "dev-install-watch": "npm install && npm run watch"
+        "dev": "vite",
+        "build": "vite build"
     },
     "devDependencies": {
+        "@rollup/plugin-inject": "^5.0.5",
+        "@vitejs/plugin-vue": "^5.0.3",
         "axios": "^1.6.0",
         "bootstrap": "^4.6.2",
         "browser-sync": "^2.28.3",
         "browser-sync-webpack-plugin": "2.3.0",
         "cross-env": "^7.0.3",
         "jquery": "^3.6.3",
-        "laravel-mix": "^6.0.49",
+        "laravel-vite-plugin": "^1.0.1",
         "lodash": "^4.17.21",
         "mix-tailwindcss": "^1.3.0",
         "popper.js": "^1.16.1",
@@ -23,6 +22,9 @@
         "sass": "^1.57.1",
         "sass-loader": "^12.4.0",
         "tippy.js": "^6.3.7",
+        "vite": "^5.1.0",
+        "vite-plugin-node-polyfills": "^0.19.0",
+        "vite-plugin-static-copy": "^1.0.1",
         "webpack": "^5.76.0"
     },
     "optionalDependencies": {
@@ -50,7 +52,7 @@
         "postcss": "^8.4.21",
         "progressbar.js": "^1.1.1",
         "protip": "^1.4.21",
-        "sanitize-html": "^2.8.1",
+        "sanitize-html": "^2.11.0",
         "select2": "^4.0.13",
         "select2-bootstrap-theme": "0.1.0-beta.10",
         "serverless-s3-sync": "^1.14.4",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,6 @@
-// postcss config
-module.exports = {
+export default {
     plugins: {
         tailwindcss: {},
         autoprefixer: {},
-    }
+    },
 }

--- a/resources/js/app-tw.js
+++ b/resources/js/app-tw.js
@@ -4,7 +4,7 @@
  * building robust, powerful web applications using Vue and Laravel.
  */
 
-require('./bootstrap-tw');
+import './bootstrap-tw';
 
 // window.CalendarClock = require('./clock')
 // window.RandomCalendar = require('./random-calendar')

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -4,20 +4,48 @@
  * building robust, powerful web applications using Vue and Laravel.
  */
 
-require('./bootstrap');
+import './bootstrap';
 
-window.CalendarClock = require('./clock')
-window.RandomCalendar = require('./random-calendar')
-window.CalendarPresets = require('./calendar-presets')
-window.Perms = require('./perms');
-window.RenderDataGenerator = require('./render-data-generator')
-window.CalendarRenderer = require('./calendar-renderer')
-window.CalendarLayouts = require('./calendar-layouts')
-window.EventsManager = require('./events-manager')
-window.CalendarEventEditor = require('./calendar-events-editor')
-window.CalendarEventViewer = require('./calendar-events-viewer')
-window.CalendarHTMLEditor = require('./calendar-html-editor')
-window.CalendarYearHeader = require('./calendar-year-header')
+import CalendarClock from './clock';
+window.CalendarClock = CalendarClock;
+
+import RandomCalendar from './random-calendar';
+window.RandomCalendar = RandomCalendar;
+
+import CalendarPresets from './calendar-presets';
+window.CalendarPresets = CalendarPresets;
+
+import Perms from './perms';
+window.Perms = Perms;
+
+import RenderDataGenerator from './render-data-generator';
+window.RenderDataGenerator = RenderDataGenerator;
+
+import CalendarRenderer from './calendar-renderer';
+window.CalendarRenderer = CalendarRenderer;
+
+import CalendarLayouts from './calendar-layouts';
+window.CalendarLayouts = CalendarLayouts;
+
+import EventsManager from './events-manager';
+window.EventsManager = EventsManager;
+
+import CalendarEventEditor from './calendar-events-editor';
+window.CalendarEventEditor = CalendarEventEditor;
+
+import CalendarEventViewer from './calendar-events-viewer';
+window.CalendarEventViewer = CalendarEventViewer;
+
+import CalendarHTMLEditor from './calendar-html-editor';
+window.CalendarHTMLEditor = CalendarHTMLEditor;
+
+import CalendarYearHeader from './calendar-year-header';
+window.CalendarYearHeader = CalendarYearHeader;
+
+import './calendar/calendar_functions.js';
+import './calendar/calendar_inputs_view.js';
+import './calendar/calendar_inputs_visitor.js';
+
 
 // Calendar specific modules
 import IntervalsCollection from "./fantasycalendar/Collections/IntervalsCollection.js";

--- a/resources/js/bootstrap-tw.js
+++ b/resources/js/bootstrap-tw.js
@@ -1,4 +1,5 @@
-window._ = require('lodash');
+import _ from 'lodash';
+window._ = _;
 
 import Alpine from 'alpinejs'
 window.Alpine = Alpine
@@ -10,7 +11,8 @@ Alpine.start()
  * CSRF token as a header based on the value of the "XSRF" token cookie.
  */
 
-window.axios = require('axios');
+import axios from 'axios';
+window.axios = axios;;
 
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 window.axios.defaults.withCredentials = true;
@@ -43,13 +45,15 @@ if (token) {
  * API, allowing confirmations and very much more. (sweetalert.js.org)
  */
 
-window.swal = require('sweetalert2')
+import swal from 'sweetalert2';
+window.swal = swal;
 
 /**
  * Sanitize HTML inputs browser-side using sanitize-html!
  */
 
-window.sanitizeHtml = require('sanitize-html');
+import * as sanitizeHtml from 'sanitize-html';
+window.sanitizeHtml = sanitizeHtml;
 
 
 /**

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -1,4 +1,5 @@
-window._ = require('lodash');
+import lodash from 'lodash';
+window._ = lodash;
 
 /**
  * We'll load jQuery and the Bootstrap jQuery plugin which provides support
@@ -6,24 +7,33 @@ window._ = require('lodash');
  * code may be modified to fit the specific needs of your application.
  */
 
-try {
-    window.Popper = require('popper.js').default;
-    window.$ = window.jQuery = require('jquery');
+import $ from 'jquery';
+window.jQuery = window.$ = $;
 
-    require('chart.js');
-    require('trumbowyg');
-    require('notifyjs');
+import popper from 'popper.js';
+window.Popper = popper;
 
-    /**
-     * Protip is a tooltip solution that works well with jQuery, but takes a modern
-     * approach to the way you actually create tooltips. In this case that means
-     * using attributes on elements in HTML, not direct javascript controls.
-     */
-    require('protip');
+import Chart from 'chart.js';
+window.Chart = Chart;
+
+// import 'trumbowyg';
+// window.trumbowyg = trumbowyg;
+
+import notifyjs from 'notifyjs';
+window.notify = $.notify = notifyjs;
+
+/**
+ * Protip is a tooltip solution that works well with jQuery, but takes a modern
+ * approach to the way you actually create tooltips. In this case that means
+ * using attributes on elements in HTML, not direct javascript controls.
+ */
+
+import 'protip';
+// window.protip = $.protip = protip;
 
 
-    require('bootstrap');
-} catch (e) {}
+import bootstrap from 'bootstrap';
+window.bootstrap = bootstrap;
 
 /**
  * We'll load the axios HTTP library which allows us to easily issue requests
@@ -31,7 +41,8 @@ try {
  * CSRF token as a header based on the value of the "XSRF" token cookie.
  */
 
-window.axios = require('axios');
+import axios from 'axios';
+window.axios = axios;
 
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 window.axios.defaults.withCredentials = true;
@@ -63,14 +74,16 @@ if (token) {
  * API, allowing confirmations and very much more. (sweetalert.js.org)
  */
 
-window.swal = require('sweetalert2')
+import sweetalert from 'sweetalert2';
+window.swal = sweetalert;
 
 /**
  * Select2 is a jQuery-based replacement for select boxes. It supports searching,
  * remote data sets, and pagination of results.
  */
 
-require('select2');
+import Select2 from 'select2';
+window.Select2 = Select2;
 
 /**
  * With ProgressBar.js, it's easy to create responsive and stylish progress
@@ -79,7 +92,8 @@ require('select2');
  * custom shaped progress bars with any vector graphic editor.
  */
 
-window.ProgressBar = require('progressbar.js');
+import ProgressBar from 'progressbar.js';
+window.ProgressBar = ProgressBar;
 
 /**
  * mustache.js is an implementation of the mustache template system in JavaScript.
@@ -88,13 +102,15 @@ window.ProgressBar = require('progressbar.js');
  * provided in a hash or object.
  */
 
-window.Mustache = require('mustache');
+import Mustache from 'mustache';
+window.Mustache = Mustache;
 
 /**
  * Sanitize HTML inputs browser-side using sanitize-html!
  */
 
-window.sanitizeHtml = require('sanitize-html');
+import * as sanitizeHtml from 'sanitize-html';
+window.sanitizeHtml = sanitizeHtml;
 
 /**
  * $.contextMenu is a management facility for - you guessed it - context menus.
@@ -103,7 +119,8 @@ window.sanitizeHtml = require('sanitize-html');
  * menus without providing actual markup, as $.contextMenu generates DOMElements as needed.
  */
 
-window.contextMenu = require('jquery-contextmenu')
+import contextMenu from 'jquery-contextmenu';
+window.contextMenu = contextMenu;
 
 /**
  * Echo exposes an expressive API for subscribing to channels and listening
@@ -111,11 +128,13 @@ window.contextMenu = require('jquery-contextmenu')
  * allows your team to easily build robust real-time web applications.
  */
 
-window.AlpineEditor = require('alpine-editor')
+// import { AlpineEditor as AlpineEditor } from 'alpine-editor';
+// window.AlpineEditor = AlpineEditor;
 
 // import Echo from 'laravel-echo'
 
-// window.Pusher = require('pusher-js');
+// import Pusher from 'pusher-js';
+// window.Pusher = Pusher;
 
 // window.Echo = new Echo({
 //     broadcaster: 'pusher',
@@ -124,11 +143,14 @@ window.AlpineEditor = require('alpine-editor')
 //     encrypted: true
 // });
 
-window.tailwindColors = require('tailwindcss/colors')
+import tailwindColors from 'tailwindcss/colors';
+window.tailwindColors = tailwindColors;
 
 /**
  * Convenient and dependency free wrapper for working with arrays and objects.
  */
-let collectJS = require('collect.js');
+import collectJS from 'collect.js';
+window.collectJS = collectJS;
+
 window.Collection = collectJS.Collection;
 window.collect = collectJS.collect;

--- a/resources/js/calendar-events-editor.js
+++ b/resources/js/calendar-events-editor.js
@@ -2598,4 +2598,4 @@ const calendar_events_editor = {
 }
 
 
-module.exports = calendar_events_editor;
+export default calendar_events_editor;

--- a/resources/js/calendar-events-viewer.js
+++ b/resources/js/calendar-events-viewer.js
@@ -320,4 +320,4 @@ const calendar_events_viewer = {
 
 }
 
-module.exports = calendar_events_viewer;
+export default calendar_events_viewer;

--- a/resources/js/calendar-html-editor.js
+++ b/resources/js/calendar-html-editor.js
@@ -118,4 +118,4 @@ const calendar_html_editor = {
 }
 
 
-module.exports = calendar_html_editor;
+export default calendar_html_editor;

--- a/resources/js/calendar-layouts.js
+++ b/resources/js/calendar-layouts.js
@@ -49,4 +49,4 @@ const calendar_layouts = {
 
 }
 
-module.exports = calendar_layouts;
+export default calendar_layouts;

--- a/resources/js/calendar-presets.js
+++ b/resources/js/calendar-presets.js
@@ -300,4 +300,4 @@ const preset_loader = {
     }
 }
 
-module.exports = preset_loader;
+export default preset_loader;

--- a/resources/js/calendar-renderer.js
+++ b/resources/js/calendar-renderer.js
@@ -158,4 +158,4 @@ const calendar_renderer = {
 
 }
 
-module.exports = calendar_renderer;
+export default calendar_renderer;

--- a/resources/js/calendar-year-header.js
+++ b/resources/js/calendar-year-header.js
@@ -130,4 +130,4 @@ const calendarYearHeader = {
 }
 
 
-module.exports = calendarYearHeader;
+export default calendarYearHeader;

--- a/resources/js/calendar/calendar_ajax_functions.js
+++ b/resources/js/calendar/calendar_ajax_functions.js
@@ -1,4 +1,4 @@
-function update_date(new_date){
+window.update_date = function(new_date){
 
 	if(dynamic_data.year != new_date.year){
 		dynamic_data.day = new_date.day;
@@ -26,12 +26,12 @@ function update_date(new_date){
 	}
 }
 
-function validateEmail(email) {
+window.validateEmail = function(email) {
 	const re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 	return re.test(email);
 }
 
-function getUrlParameter(sParam) {
+window.getUrlParameter = function(sParam) {
 	var sPageURL = decodeURIComponent(window.location.search.substring(1)),
 		sURLVariables = sPageURL.split('&'),
 		sParameterName,
@@ -46,7 +46,7 @@ function getUrlParameter(sParam) {
 	}
 };
 
-function update_name(){
+window.update_name = function(){
 	$.ajax({
 		url:window.baseurl+"calendars/"+hash,
 		type: "post",
@@ -67,7 +67,7 @@ function update_name(){
 	});
 }
 
-function update_view_dynamic(calendar_hash){
+window.update_view_dynamic = function(calendar_hash){
 
 	$.ajax({
 		url:window.baseurl+"calendars/"+calendar_hash,
@@ -88,7 +88,7 @@ function update_view_dynamic(calendar_hash){
 }
 
 
-function update_dynamic(calendar_hash, callback){
+window.update_dynamic = function(calendar_hash, callback){
 
 	$.ajax({
 		url:window.baseurl+"calendars/"+calendar_hash,
@@ -121,7 +121,7 @@ function update_dynamic(calendar_hash, callback){
 
 }
 
-function update_all(){
+window.update_all = function(){
 
 	check_last_change(hash, function(output){
 
@@ -142,7 +142,7 @@ function update_all(){
 	});
 }
 
-function do_update_all(calendar_hash, success_callback, failure_callback){
+window.do_update_all = function(calendar_hash, success_callback, failure_callback){
 
 	$.ajax({
 		url:window.baseurl+"calendars/"+calendar_hash,
@@ -202,7 +202,7 @@ function do_update_all(calendar_hash, success_callback, failure_callback){
 	});
 }
 
-function get_all_data(calendar_hash, output){
+window.get_all_data = function(calendar_hash, output){
 
 	$.ajax({
 		url:window.apiurl+"/calendar/"+calendar_hash,
@@ -221,7 +221,7 @@ function get_all_data(calendar_hash, output){
 	});
 }
 
-function get_dynamic_data(calendar_hash, output){
+window.get_dynamic_data = function(calendar_hash, output){
 
 	$.ajax({
 		url:window.apiurl+"/calendar/"+calendar_hash+"/dynamic_data",
@@ -243,7 +243,7 @@ function get_dynamic_data(calendar_hash, output){
 
 }
 
-function link_child_calendar(child_hash, parent_link_date, parent_offset){
+window.link_child_calendar = function(child_hash, parent_link_date, parent_offset){
 
 	show_loading_screen();
 
@@ -269,7 +269,7 @@ $.ajax({
 });
 }
 
-function unlink_child_calendar(output, child_hash){
+window.unlink_child_calendar = function(output, child_hash){
 
 	show_loading_screen();
 
@@ -297,7 +297,7 @@ function unlink_child_calendar(output, child_hash){
     });
 }
 
-function get_calendar_users(callback) {
+window.get_calendar_users = function(callback) {
     $.ajax({
         url: window.apiurl+"/calendar/"+hash+"/users",
         type: "get",
@@ -311,7 +311,7 @@ function get_calendar_users(callback) {
     })
 }
 
-function add_calendar_user(email, output){
+window.add_calendar_user = function(email, output){
     axios.post(window.apiurl+"/calendar/"+hash+"/inviteUser", {email: email})
         .then(function(result) {
             output(true, `Sent email to ${email}!`);
@@ -321,7 +321,7 @@ function add_calendar_user(email, output){
         });
 }
 
-function update_calendar_user(user_id, permission, output){
+window.update_calendar_user = function(user_id, permission, output){
 
     axios.post(window.apiurl+"/calendar/"+hash+"/changeUserRole", {user_role: permission, user_id: user_id})
         .then(function(result) {
@@ -332,7 +332,7 @@ function update_calendar_user(user_id, permission, output){
         });
 }
 
-function remove_calendar_user(user_id, remove_all, callback, email = null){
+window.remove_calendar_user = function(user_id, remove_all, callback, email = null){
 
     let userdata = {user_id: user_id, remove_all: remove_all};
     if(email) {
@@ -350,7 +350,7 @@ function remove_calendar_user(user_id, remove_all, callback, email = null){
         });
 }
 
-function resend_calendar_invite(email, output){
+window.resend_calendar_invite = function(email, output){
 
     axios.post(window.apiurl+"/calendar/"+hash+"/resend_invite", {email: email})
         .then(function(result){
@@ -395,7 +395,7 @@ async function submit_new_event(event_id, callback){
     });
 }
 
-function submit_hide_show_event(event_id){
+window.submit_hide_show_event = function(event_id){
 
 	var edit_event = clone(events[event_id]);
 	edit_event.calendar_id = calendar_id;
@@ -420,7 +420,7 @@ function submit_hide_show_event(event_id){
     });
 }
 
-function submit_edit_event(event_id, callback){
+window.submit_edit_event = function(event_id, callback){
 
 	var edit_event = clone(events[event_id]);
 	edit_event.calendar_id = calendar_id;
@@ -440,7 +440,7 @@ function submit_edit_event(event_id, callback){
     });
 }
 
-function submit_delete_event(event_id, callback){
+window.submit_delete_event = function(event_id, callback){
 
 	$.ajax({
 		url:window.apiurl+"/event/"+event_id,
@@ -467,7 +467,7 @@ function submit_delete_event(event_id, callback){
 }
 
 
-function get_event_comments(event_id, callback){
+window.get_event_comments = function(event_id, callback){
 	$.ajax({
 		url: window.apiurl+"/eventcomment/event/"+event_id,
 		type: "get",
@@ -482,7 +482,7 @@ function get_event_comments(event_id, callback){
 
 }
 
-function submit_new_comment(content, event_id, callback) {
+window.submit_new_comment = function(content, event_id, callback) {
 
     axios.post(window.apiurl+"/eventcomment", {
         calendar_id: calendar_id,
@@ -504,7 +504,7 @@ function submit_new_comment(content, event_id, callback) {
         });
 }
 
-function submit_edit_comment(comment_id, content, callback){
+window.submit_edit_comment = function(comment_id, content, callback){
 
     axios.patch(window.apiurl+"/eventcomment/"+comment_id, {
 		content: content
@@ -529,7 +529,7 @@ function submit_edit_comment(comment_id, content, callback){
 
 }
 
-function submit_delete_comment(comment_id, callback){
+window.submit_delete_comment = function(comment_id, callback){
 
     axios.delete(window.apiurl+"/eventcomment/"+comment_id)
         .then(function (result){
@@ -549,7 +549,7 @@ function submit_delete_comment(comment_id, callback){
 }
 
 
-function get_owned_calendars(output){
+window.get_owned_calendars = function(output){
 	$.ajax({
 		url:window.apiurl+"/calendar/"+hash+"/owned",
 		type: "get",
@@ -567,7 +567,7 @@ function get_owned_calendars(output){
 	});
 }
 
-function check_last_change(calendar_hash, output){
+window.check_last_change = function(calendar_hash, output){
 	$.ajax({
 		url:window.apiurl+"/calendar/"+calendar_hash+"/last_changed",
 		type: "post",
@@ -585,7 +585,7 @@ function check_last_change(calendar_hash, output){
 	});
 }
 
-function delete_calendar(calendar_hash, calendar_name, callback){
+window.delete_calendar = function(calendar_hash, calendar_name, callback){
 
     swal.fire({
         text: "If you're sure about deleting this calendar, please type '" + calendar_name + "' below:",
@@ -632,7 +632,7 @@ function delete_calendar(calendar_hash, calendar_name, callback){
 
 }
 
-function copy_calendar(calendar_hash, calendar_name, callback){
+window.copy_calendar = function(calendar_hash, calendar_name, callback){
 
     swal.fire({
         text: "What would you like to call your new copy of '" + calendar_name + "'?",
@@ -690,7 +690,7 @@ function copy_calendar(calendar_hash, calendar_name, callback){
 
 }
 
-function create_calendar(callback){
+window.create_calendar = function(callback){
 
 	$.ajax({
 		url:window.baseurl+"calendars",
@@ -718,7 +718,7 @@ function create_calendar(callback){
 }
 
 
-function get_event_comments(event_id, callback){
+window.get_event_comments = function(event_id, callback){
 
 	$.ajax({
 		url: window.apiurl+"/eventcomment/event/"+event_id,
@@ -734,7 +734,7 @@ function get_event_comments(event_id, callback){
 
 }
 
-function create_event_comment(content, event_id, callback) {
+window.create_event_comment = function(content, event_id, callback) {
 
     axios.post(window.apiurl+"/eventcomment", {
         calendar_id: calendar_id,
@@ -756,7 +756,7 @@ function create_event_comment(content, event_id, callback) {
         });
 }
 
-function get_preset_data(preset_id, callback){
+window.get_preset_data = function(preset_id, callback){
 
 	axios.get(window.apiurl+'/preset/'+preset_id)
 		.then(function (result){

--- a/resources/js/calendar/calendar_functions.js
+++ b/resources/js/calendar/calendar_functions.js
@@ -1,6 +1,6 @@
-(function(b,c){var $=b.jQuery||b.Cowboy||(b.Cowboy={}),a;$.throttle=a=function(e,f,j,i){var h,d=0;if(typeof f!=="boolean"){i=j;j=f;f=c}function g(){var o=this,m=+new Date()-d,n=arguments;function l(){d=+new Date();j.apply(o,n)}function k(){h=c}if(i&&!h){l()}h&&clearTimeout(h);if(i===c&&m>e){l()}else{if(f!==true){h=setTimeout(i?k:l,i===c?e-m:e)}}}if($.guid){g.guid=j.guid=j.guid||$.guid++}return g};$.debounce=function(d,e,f){return f===c?a(d,e,false):a(d,f,e!==false)}})(this);
+// (function(b,c){var $=b.jQuery||b.Cowboy||(b.Cowboy={}),a;$.throttle=a=function(e,f,j,i){var h,d=0;if(typeof f!=="boolean"){i=j;j=f;f=c}function g(){var o=this,m=+new Date()-d,n=arguments;function l(){d=+new Date();j.apply(o,n)}function k(){h=c}if(i&&!h){l()}h&&clearTimeout(h);if(i===c&&m>e){l()}else{if(f!==true){h=setTimeout(i?k:l,i===c?e-m:e)}}}if($.guid){g.guid=j.guid=j.guid||$.guid++}return g};$.debounce=function(d,e,f){return f===c?a(d,e,false):a(d,f,e!==false)}})(this);
 
-function escapeHtml(unsafe) {
+window.escapeHtml = function(unsafe) {
     return unsafe
          .replace(/&/g, "&amp;")
          .replace(/</g, "&lt;")
@@ -9,7 +9,7 @@ function escapeHtml(unsafe) {
          .replace(/'/g, "&#039;");
  }
 
-function unescapeHtml(safe) {
+window.unescapeHtml = function(safe) {
 	if(!isNaN(safe)) return safe;
 	return safe
 			.replace(/&amp;/g, '&')
@@ -40,7 +40,7 @@ var execution_time = {
 	}
 }
 
-function is_past_current_date(dynamic_data, year, timespan, day){
+window.is_past_current_date = function(dynamic_data, year, timespan, day){
 
 	if(year !== undefined && timespan !== undefined && day !== undefined){
 		return (
@@ -61,7 +61,7 @@ function is_past_current_date(dynamic_data, year, timespan, day){
 
 }
 
-function get_colors_for_season(season_name) {
+window.get_colors_for_season = function(season_name) {
 	let index = ['spring', 'summer', 'autumn', 'winter', 'fall'].indexOf(season_name.toLowerCase());
 	if(index != -1) {
 		if(index == 0) return "#1ee313";
@@ -73,19 +73,19 @@ function get_colors_for_season(season_name) {
 	}
 }
 
-function fahrenheit_to_celcius(temp){
+window.fahrenheit_to_celcius = function(temp){
 
 	return precisionRound((temp-32)*(5/9), 4);
 
 }
 
-function celcius_to_fahrenheit(temp){
+window.celcius_to_fahrenheit = function(temp){
 
 	return precisionRound((temp*9/5)+32, 4);
 
 }
 
-function pick_from_table(chance, array, grow){
+window.pick_from_table = function(chance, array, grow){
 
 	var grow = grow !== undefined ? grow : false;
 	var keys = Object.keys(array);
@@ -111,7 +111,7 @@ function pick_from_table(chance, array, grow){
 
 }
 
-function matcher(params, data){
+window.matcher = function(params, data){
 
     // If there are no search terms, return all of the data
     if ($.trim(params.term) === '') {
@@ -165,7 +165,7 @@ function matcher(params, data){
     return null;
 }
 
-function truncate_weekdays(weekday_array){
+window.truncate_weekdays = function(weekday_array){
 
 	var new_array = [];
 
@@ -200,7 +200,7 @@ function truncate_weekdays(weekday_array){
 }
 
 
-function is_roman_numeral(string){
+window.is_roman_numeral = function(string){
 	var regex = /^(?=[MDCLXVI])M*(C[MD]|D?C*)(X[CL]|L?X*)(I[XV]|V?I*)$/i;
 
 	return regex.test(string.toUpperCase());
@@ -213,7 +213,7 @@ function is_roman_numeral(string){
  *                                  Formatted like: "static_data.year_data.timespans.1.interval"
  * @return {object}                 Returns a reference to the object found
  */
-function get_calendar_data(data){
+window.get_calendar_data = function(data){
 	data = data.split('.')
 	if(data[0] !== ""){
 		var current_calendar_data = static_data[data[0]];
@@ -233,7 +233,7 @@ function get_calendar_data(data){
  * @param  {int}        wait        The amount of time to wait in seconds
  * @param  {bool}       immediate   Whether the function should be called immediately (right now)
  */
-function debounce(func, wait, immediate) {
+window.debounce = function(func, wait, immediate) {
 	var timeout;
 	return function() {
 		var context = this, args = arguments;
@@ -283,7 +283,7 @@ Object.compare = function (obj1, obj2) {
 	return true;
 };
 
-function capitalizeFirstLetter(string) {
+window.capitalizeFirstLetter = function(string) {
 	return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
@@ -293,7 +293,7 @@ function capitalizeFirstLetter(string) {
  * @param  {int}     i      An integer to turn into a string
  * @return {string}         A string of the number and "st", "nd", "rd", or "th"
  */
-function ordinal_suffix_of(i){
+window.ordinal_suffix_of = function(i){
 	var j = i % 10,
 	k = i % 100;
 	if (j == 1 && k != 11){
@@ -308,11 +308,11 @@ function ordinal_suffix_of(i){
 	return i + "th";
 }
 
-function replaceAt(string, index, replacement) {
+window.replaceAt = function(string, index, replacement) {
 	return string.substr(0, index) + replacement+ string.substr(index + replacement.length);
 }
 
-function mod(n, m) {
+window.mod = function(n, m) {
     return ((n % m) + m) % m;
 }
 
@@ -431,7 +431,7 @@ class random {
 	}
 }
 
-function bezierQuadratic(p0, p1, p2, t)
+window.bezierQuadratic = function(p0, p1, p2, t)
 {
 	// mix is linear interpolation, aka. linear bezier
 	return lerp(
@@ -440,7 +440,7 @@ function bezierQuadratic(p0, p1, p2, t)
 		t
 	);
 }
-function  bezierCubic(p0, p1, p2, p3, t)
+window. bezierCubic = function(p0, p1, p2, p3, t)
 {
 	return lerp(
 		bezierQuadratic(p0, p1, p2, t),
@@ -457,7 +457,7 @@ function  bezierCubic(p0, p1, p2, p3, t)
  * @param  {number}  precision   An int to determine how many digits to keep in the fraction of the number
  * @return {number}              The precision-rounded value
  */
-function precisionRound(number, precision) {
+window.precisionRound = function(number, precision) {
 	var factor = Math.pow(10, precision);
 	return Math.round(number * factor) / factor;
 }
@@ -471,7 +471,7 @@ function precisionRound(number, precision) {
  * @param  {float}  max     Maximum value
  * @return {float}          The clamped value
  */
-function clamp(t, min, max){
+window.clamp = function(t, min, max){
 	return Math.min(Math.max(t, min), max);
 }
 
@@ -484,7 +484,7 @@ function clamp(t, min, max){
  * @param  {float}  t       A normalized value between 0.0 and 1.0, 0.0 returning p0 and 1.0 returning p1
  * @return {float}          The interpolated value
  */
-function lerp(p0, p1, t){
+window.lerp = function(p0, p1, t){
 	return p0 + t*(p1 - p0);
 }
 
@@ -495,7 +495,7 @@ function lerp(p0, p1, t){
  * @param  {float}    float     The float
  * @return {float}              The fraction of that value
  */
-function fract(float){
+window.fract = function(float){
 	return float - Math.floor(float);
 }
 
@@ -507,7 +507,7 @@ function fract(float){
  * @param  {float}    p1    The second value
  * @return {float}          The middle value
  */
-function mid(p0, p1){
+window.mid = function(p0, p1){
 	return (p0+p1)/2;
 }
 
@@ -520,7 +520,7 @@ function mid(p0, p1){
  * @param  {float}  max     The maximum value
  * @return {float}          The normalized value
  */
-function norm(v, min, max)
+window.norm = function(v, min, max)
 {
 	return (v - min) / (max - min);
 }
@@ -533,7 +533,7 @@ function norm(v, min, max)
  * @param  {float}  max     The maximum value
  * @return {float}          The normalized value
  */
-function inv_norm(v, min, max)
+window.inv_norm = function(v, min, max)
 {
 	return (max - v) / (max - min);
 }
@@ -546,7 +546,7 @@ function inv_norm(v, min, max)
  * @param  {float}  cycle   The cycle of a moon
  * @return {int}            The given level of granularity suggested for that cycle
  */
-function get_moon_granularity(cycle){
+window.get_moon_granularity = function(cycle){
 	if(cycle >= 40){
 		return 40;
 	}else if(cycle >= 24){
@@ -560,7 +560,7 @@ function get_moon_granularity(cycle){
 	}
 }
 
-function get_current_era(static_data, epoch){
+window.get_current_era = function(static_data, epoch){
 
 	if(static_data.eras === undefined || static_data.eras.length == 0){
 		return -1;
@@ -591,7 +591,7 @@ function get_current_era(static_data, epoch){
 }
 
 
-class date_manager {
+export class date_manager {
 
 	constructor(year, timespan, day){
 
@@ -879,7 +879,7 @@ class date_manager {
 
 }
 
-function valid_preview_date(year, timespan, day){
+window.valid_preview_date = function(year, timespan, day){
 
     if(!static_data.settings.allow_view){
         return false;
@@ -930,7 +930,7 @@ function valid_preview_date(year, timespan, day){
  *                              "text" - The text to be displayed at the top of the calendar
  *                              "array" - An array containing each index (ints) that indicates which part of the cycle each of them is in
  */
-function get_cycle(static_data, epoch_data){
+window.get_cycle = function(static_data, epoch_data){
 
 	var text = {
 		"n": "<br>"
@@ -993,7 +993,7 @@ function get_cycle(static_data, epoch_data){
  * @param  {int}        leap_day_index  The index of the leap day
  * @return {bool}                       A boolean, indicating if the leap day appears on that month
  */
-function does_leap_day_appear(static_data, year, timespan_index, leap_day_index){
+window.does_leap_day_appear = function(static_data, year, timespan_index, leap_day_index){
 
 	let timespan_appears = does_timespan_appear(static_data, year, timespan_index).result;
 
@@ -1016,7 +1016,7 @@ function does_leap_day_appear(static_data, year, timespan_index, leap_day_index)
  * @param  {int}        year            The a number of a year
  * @return {int}                        The absolute year
  */
-function convert_year(static_data, year){
+window.convert_year = function(static_data, year){
 	if(static_data.settings.year_zero_exists){
 		return year;
 	}else{
@@ -1033,7 +1033,7 @@ function convert_year(static_data, year){
  * @param  {int}        year            The a number of a year
  * @return {int}                        The absolute year
  */
-function unconvert_year(static_data, year){
+window.unconvert_year = function(static_data, year){
 	if(static_data.settings.year_zero_exists){
 		return year;
 	}else{
@@ -1052,7 +1052,7 @@ function unconvert_year(static_data, year){
  * @param  {obj}        self_object     Not sure what this is for anymore, but I believe this was to be able to target specific leap days.
  * @return {array}                      An array containing strings for each day
  */
-function get_days_in_timespan(static_data, year, timespan_index, self_object, no_leaps, special){
+window.get_days_in_timespan = function(static_data, year, timespan_index, self_object, no_leaps, special){
 
 	self_object = self_object !== undefined ? self_object : false;
 	no_leaps = no_leaps !== undefined ? no_leaps : false;
@@ -1149,7 +1149,7 @@ function get_days_in_timespan(static_data, year, timespan_index, self_object, no
  *                                          result - boolean, true if the timespan appears on the given date
  *                                          reason - reason for the timespan to gone, only present if result is false
  */
-function get_timespans_in_year(static_data, year, inclusive){
+window.get_timespans_in_year = function(static_data, year, inclusive){
 
 	var results = [];
 
@@ -1182,7 +1182,7 @@ function get_timespans_in_year(static_data, year, inclusive){
  *                                          result - boolean, true if the timespan appears on the given date
  *                                          reason - reason for the timespan to gone, only present if result is false
  */
-function does_timespan_appear(static_data, year, timespan){
+window.does_timespan_appear = function(static_data, year, timespan){
 
 	for(var era_index = 0; era_index < static_data.eras.length; era_index++){
 
@@ -1237,7 +1237,7 @@ function does_timespan_appear(static_data, year, timespan){
  *                                          result - boolean, true if the day appears on the given date
  *                                          reason - reason for the day to gone, only present if result is false
  */
-function does_day_appear(static_data, year, timespan, day){
+window.does_day_appear = function(static_data, year, timespan, day){
 
 	for(var era_index = 0; era_index < static_data.eras.length; era_index++){
 
@@ -1268,7 +1268,7 @@ function does_day_appear(static_data, year, timespan, day){
  * @param  {object}    static_data     A calendar static data object
  * @return {float}                     The current calendar's average year length
  */
-function avg_year_length(static_data){
+window.avg_year_length = function(static_data){
 
 	let avg_length = 0;
 
@@ -1301,7 +1301,7 @@ function avg_year_length(static_data){
  * @param  {object}     static_data     A calendar static data object
  * @return {number}                     The current calendar's average month length
  */
-function avg_month_length(static_data){
+window.avg_month_length = function(static_data){
 
 	let length = 0;
 	let num_months = 0;
@@ -1339,7 +1339,7 @@ function avg_month_length(static_data){
  * @param  {object}     obj     A javascript object
  * @return {object}             An identical javascript object with no references tied to the incoming object
  */
-function clone(obj) {
+window.clone = function(obj) {
 	var copy;
 
 	// Handle the 3 simple types, and null or undefined
@@ -1373,7 +1373,7 @@ function clone(obj) {
 	throw new Error("Unable to copy obj! Its type isn't supported.");
 }
 
-function time_data_to_string(static_data, time){
+window.time_data_to_string = function(static_data, time){
 
 	var minutes = (Math.round(fract(time)*this.static_data.clock.minutes)).toString().length < 2 ? "0"+(Math.round(fract(time)*this.static_data.clock.minutes)).toString() : (Math.round(fract(time)*this.static_data.clock.minutes));
 
@@ -1381,7 +1381,7 @@ function time_data_to_string(static_data, time){
 
 }
 
-function is_leap_simple(static_data, year, interval, offset, debug) {
+window.is_leap_simple = function(static_data, year, interval, offset, debug) {
 
     if(interval === 1) return true;
 
@@ -1395,7 +1395,7 @@ function is_leap_simple(static_data, year, interval, offset, debug) {
 
 }
 
-function get_timespan_occurrences(static_data, year, interval, offset){
+window.get_timespan_occurrences = function(static_data, year, interval, offset){
 
     if(interval === 1) return year;
 
@@ -1440,7 +1440,7 @@ function get_timespan_occurrences(static_data, year, interval, offset){
  *                                          3: num_timespans - The total number of timespans since year 1
  *                                          4: total_week_num - The number of weeks since year 1
  */
-function get_epoch(static_data, year, _timespan, _day, debug){
+window.get_epoch = function(static_data, year, _timespan, _day, debug){
 
 	// Set up variables
 	let epoch = 0;
@@ -1541,7 +1541,7 @@ function get_epoch(static_data, year, _timespan, _day, debug){
  *                                          "num_timespans" - The total number of timespans since year 1
  *                                          "total_week_num" - The number of weeks since year 1
  */
-function evaluate_calendar_start(static_data, _year, _timespan, _day, debug){
+window.evaluate_calendar_start = function(static_data, _year, _timespan, _day, debug){
 
 	//Initiatlize variables
 	let year = (_year|0);
@@ -1664,7 +1664,7 @@ function evaluate_calendar_start(static_data, _year, _timespan, _day, debug){
 
 }
 
-function toggle_sidebar(force = null) {
+window.toggle_sidebar = function(force = null) {
     if (force === true) {
         $("#input_container").addClass('inputs_collapsed');
         $("#calendar_container").addClass('inputs_collapsed');
@@ -1695,7 +1695,7 @@ function toggle_sidebar(force = null) {
  * @param  {int}        year            The number of a year passed through the convert_year function.
  * @return {bool}                       A boolean to indicate whether that year has been terminated by an era or not
  */
-function has_year_ending_era(static_data, year){
+window.has_year_ending_era = function(static_data, year){
 
 	for(var era_index = 0; era_index < static_data.eras.length; era_index++){
 

--- a/resources/js/calendar/calendar_inputs_view.js
+++ b/resources/js/calendar/calendar_inputs_view.js
@@ -1,6 +1,6 @@
-rebuild_type = 'calendar';
+window.rebuild_type = 'calendar';
 
-function set_up_view_inputs(){
+window.set_up_view_inputs = function(){
 
 	/* if(just_converted && !JSON.parse(localStorage.getItem('hide_welcome_back'))){
 
@@ -335,7 +335,7 @@ function set_up_view_inputs(){
 }
 
 
-function increment_date_units(current){
+window.increment_date_units = function(current){
 
 	var unit_years = $('#unit_years').val()|0;
 	var unit_months = $('#unit_months').val()|0;
@@ -410,7 +410,7 @@ function increment_date_units(current){
 
 }
 
-function evaluate_dynamic_change(){
+window.evaluate_dynamic_change = function(){
 
 	if(dynamic_date_manager.adjusted_year != current_year.val()|0){
 		current_year.change()
@@ -467,7 +467,7 @@ function evaluate_dynamic_change(){
 
 }
 
-function repopulate_location_select_list(){
+window.repopulate_location_select_list = function(){
 
 	if(!creation.is_done()){
 		return;
@@ -515,7 +515,7 @@ function repopulate_location_select_list(){
 
 }
 
-function set_up_view_values(){
+window.set_up_view_values = function(){
 
 	dynamic_date_manager = new date_manager(dynamic_data.year, dynamic_data.timespan, dynamic_data.day);
 

--- a/resources/js/calendar/calendar_inputs_visitor.js
+++ b/resources/js/calendar/calendar_inputs_visitor.js
@@ -1,4 +1,4 @@
-function context_set_current_date(key, opt){
+window.context_set_current_date = function(key, opt){
 
 	var epoch = $(opt.$trigger[0]).attr('epoch');
 
@@ -13,7 +13,7 @@ function context_set_current_date(key, opt){
 
 }
 
-function context_set_preview_date(key, opt){
+window.context_set_preview_date = function(key, opt){
 
 	var epoch = $(opt.$trigger[0]).attr('epoch');
 
@@ -22,7 +22,7 @@ function context_set_preview_date(key, opt){
 	set_preview_date(epoch_data.year, epoch_data.timespan_number, epoch_data.day, epoch_data.epoch);
 }
 
-function context_copy_link_date(element){
+window.context_copy_link_date = function(element){
 
 	var epoch = element.attr('epoch')|0;
 
@@ -58,7 +58,7 @@ function context_copy_link_date(element){
 	}
 }
 
-function copy_link(epoch_data){
+window.copy_link = function(epoch_data){
 
 	var year = epoch_data.year;
 	var timespan = epoch_data.timespan_number;
@@ -87,12 +87,12 @@ function copy_link(epoch_data){
 
 }
 
-function context_add_event(key, opt){
+window.context_add_event = function(key, opt){
 	var epoch = $(opt.$trigger[0]).attr('epoch')|0;
 	window.dispatchEvent(new CustomEvent('event-editor-modal-new-event', { detail: { name: "", epoch: epoch } }));
 }
 
-function context_open_day_data(key, opt){
+window.context_open_day_data = function(key, opt){
 
 	var day_element = $(opt.$trigger[0]);
 	var epoch = day_element.attr('epoch')|0;
@@ -101,7 +101,7 @@ function context_open_day_data(key, opt){
 
 }
 
-function set_up_visitor_inputs(){
+window.set_up_visitor_inputs = function(){
 
     document.addEventListener('keydown', function(event) {
         if(event.code === 'AltLeft') {
@@ -423,28 +423,28 @@ function set_up_visitor_inputs(){
 		}
 	});
 
-	target_year = $('#target_year');
-	target_timespan = $('#target_timespan');
-	target_day = $('#target_day');
+	let target_year = $('#target_year');
+	let target_timespan = $('#target_timespan');
+	let target_day = $('#target_day');
 
-	follower_buttons = $('.btn_container');
+	let follower_buttons = $('.btn_container');
 
-	follower_year_buttons = $('.btn_preview_date[fc-index="year"]');
-	follower_year_buttons_sub = $('.btn_preview_date[fc-index="year"][value="-1"]');
-	follower_year_buttons_add = $('.btn_preview_date[fc-index="year"][value="1"]');
+	let follower_year_buttons = $('.btn_preview_date[fc-index="year"]');
+	let follower_year_buttons_sub = $('.btn_preview_date[fc-index="year"][value="-1"]');
+	let follower_year_buttons_add = $('.btn_preview_date[fc-index="year"][value="1"]');
 
-	follower_timespan_buttons = $('.btn_preview_date[fc-index="timespan"]');
-	follower_timespan_buttons_sub = $('.btn_preview_date[fc-index="timespan"][value="-1"]');
-	follower_timespan_buttons_add = $('.btn_preview_date[fc-index="timespan"][value="1"]');
+	let follower_timespan_buttons = $('.btn_preview_date[fc-index="timespan"]');
+	let follower_timespan_buttons_sub = $('.btn_preview_date[fc-index="timespan"][value="-1"]');
+	let follower_timespan_buttons_add = $('.btn_preview_date[fc-index="timespan"][value="1"]');
 
-	sub_target_year = $('#sub_target_year');
-	add_target_year = $('#add_target_year');
+	let sub_target_year = $('#sub_target_year');
+	let add_target_year = $('#add_target_year');
 
-	sub_target_timespan = $('#sub_target_timespan');
-	add_target_timespan = $('#add_target_timespan');
+	let sub_target_timespan = $('#sub_target_timespan');
+	let add_target_timespan = $('#add_target_timespan');
 
-	sub_target_day = $('#sub_target_day');
-	add_target_day = $('#add_target_day');
+	let sub_target_day = $('#sub_target_day');
+	let add_target_day = $('#add_target_day');
 
 
 	$('.btn_preview_date').click(function(){
@@ -598,7 +598,7 @@ function set_up_visitor_inputs(){
 }
 
 
-function preview_date_follow(){
+window.preview_date_follow = function(){
 
 	if(preview_date.follow){
 
@@ -615,7 +615,7 @@ function preview_date_follow(){
 
 }
 
-function evaluate_preview_change(){
+window.evaluate_preview_change = function(){
 
 	if(preview_date_manager.adjusted_year != target_year.val()|0){
 		target_year.change()
@@ -627,14 +627,14 @@ function evaluate_preview_change(){
 
 }
 
-function refresh_preview_inputs(){
+window.refresh_preview_inputs = function(){
 	target_year.val(preview_date_manager.adjusted_year);
 	repopulate_timespan_select(target_timespan, preview_date_manager.timespan, false, preview_date_manager.last_valid_timespan);
 	repopulate_day_select(target_day, preview_date_manager.day, false, false, preview_date_manager.last_valid_day);
 }
 
 
-function update_preview_calendar(){
+window.update_preview_calendar = function(){
 
 	preview_date_manager = new date_manager(target_year.val()|0, target_timespan.val()|0, target_day.val()|0);
 
@@ -645,7 +645,7 @@ function update_preview_calendar(){
 
 }
 
-function set_preview_date(year, timespan, day, epoch){
+window.set_preview_date = function(year, timespan, day, epoch){
 
 	preview_date_manager.year = convert_year(static_data, year);
 	preview_date_manager.timespan = timespan;
@@ -661,7 +661,7 @@ function set_preview_date(year, timespan, day, epoch){
 }
 
 
-function go_to_preview_date(rebuild){
+window.go_to_preview_date = function(rebuild){
 
 	preview_date.follow = false;
 
@@ -694,7 +694,7 @@ function go_to_preview_date(rebuild){
 
 }
 
-function display_preview_back_button(){
+window.display_preview_back_button = function(){
 
 	if(preview_date.epoch != dynamic_data.epoch){
 		$('.reset_preview_date_container.right .reset_preview_date')
@@ -724,7 +724,7 @@ function display_preview_back_button(){
 
 }
 
-function update_current_day(recalculate){
+window.update_current_day = function(recalculate){
 
     if(recalculate){
         dynamic_data.epoch = evaluate_calendar_start(static_data, convert_year(static_data, dynamic_data.year), dynamic_data.timespan, dynamic_data.day).epoch;
@@ -739,7 +739,7 @@ function update_current_day(recalculate){
 
 }
 
-function go_to_dynamic_date(rebuild){
+window.go_to_dynamic_date = function(rebuild){
 
 	preview_date.follow = true
 
@@ -768,7 +768,7 @@ function go_to_dynamic_date(rebuild){
 
 }
 
-function evaluate_settings(){
+window.evaluate_settings = function(){
 
 	if(static_data){
 		if(static_data.year_data.global_week.length == 0 || static_data.year_data.timespans.length == 0){
@@ -826,7 +826,7 @@ function evaluate_settings(){
 }
 
 
-function eval_clock(){
+window.eval_clock = function(){
 
 	if(!Perms.user_can_see_clock()){
 		$('#clock').css('display', 'none');
@@ -859,7 +859,7 @@ function eval_clock(){
 
 }
 
-function eval_current_time(){
+window.eval_current_time = function(){
 
 	if(!Perms.user_can_see_clock()){
 		$('#clock').css('display', 'none');
@@ -872,7 +872,7 @@ function eval_current_time(){
 
 }
 
-function evaluate_sun(){
+window.evaluate_sun = function(){
 
 	if(!Perms.user_can_see_clock()){
 		$('#clock').css('display', 'none');
@@ -891,7 +891,7 @@ function evaluate_sun(){
 
 }
 
-function repopulate_event_category_lists(){
+window.repopulate_event_category_lists = function(){
 
 	var html = [];
 	html.push("<option selected value='-1'>None</option>")
@@ -922,7 +922,7 @@ function repopulate_event_category_lists(){
     $('#default_event_category').val(default_event_category.id);
 }
 
-function repopulate_timespan_select(select, val, change, max){
+window.repopulate_timespan_select = function(select, val, change, max){
 
 	if(static_data.year_data.timespans.length == 0 || static_data.year_data.global_week.length == 0) return;
 
@@ -997,7 +997,7 @@ function repopulate_timespan_select(select, val, change, max){
 
 }
 
-function repopulate_day_select(select, val, change, no_leaps, max, filter_timespan){
+window.repopulate_day_select = function(select, val, change, no_leaps, max, filter_timespan){
 
 	if(static_data.year_data.timespans.length == 0 || static_data.year_data.global_week.length == 0) return;
 
@@ -1081,7 +1081,7 @@ function repopulate_day_select(select, val, change, no_leaps, max, filter_timesp
 
 }
 
-function set_up_visitor_values(){
+window.set_up_visitor_values = function(){
 
 	preview_date.follow = true;
 

--- a/resources/js/clock.js
+++ b/resources/js/clock.js
@@ -555,4 +555,4 @@ class Clock {
     }
 }
 
-module.exports = Clock;
+export default Clock;

--- a/resources/js/events-manager.js
+++ b/resources/js/events-manager.js
@@ -311,4 +311,4 @@ const events_manager = {
     },
 };
 
-module.exports = events_manager;
+export default events_manager;

--- a/resources/js/perms.js
+++ b/resources/js/perms.js
@@ -53,4 +53,4 @@ class Perms {
     }
 }
 
-module.exports = Perms;
+export default Perms;

--- a/resources/js/protip.d.ts
+++ b/resources/js/protip.d.ts
@@ -1,0 +1,1 @@
+declare module 'protip';

--- a/resources/js/random-calendar.js
+++ b/resources/js/random-calendar.js
@@ -181,4 +181,4 @@ class RandomCalendar{
 
 }
 
-module.exports = RandomCalendar;
+export default RandomCalendar;

--- a/resources/js/render-data-generator.js
+++ b/resources/js/render-data-generator.js
@@ -668,4 +668,4 @@ const render_data_generator = {
     }
 }
 
-module.exports = render_data_generator;
+export default render_data_generator;

--- a/resources/sass/app-dark.scss
+++ b/resources/sass/app-dark.scss
@@ -7,11 +7,11 @@ html { font-family: 'Inter', sans-serif; }
 
 @import 'calendar/colors';
 @import 'darkly-twishvars';
-@import '~bootstrap/scss/bootstrap';
-@import '~bootswatch/dist/darkly/bootswatch';
+@import 'bootstrap/scss/bootstrap';
+@import 'bootswatch/dist/darkly/bootswatch';
 
 
-@import '~sweetalert2/src/variables';
+@import 'sweetalert2/src/variables';
 
 $swal2-dark-theme-black: $gray-800;
 $swal2-dark-theme-white: $gray-100;
@@ -49,12 +49,12 @@ $swal2-button-focus-box-shadow: 0 0 0 1px $swal2-background, 0 0 0 3px $swal2-ou
 $swal2-toast-background: $swal2-dark-theme-black;
 $swal2-toast-button-focus-box-shadow: 0 0 0 1px $swal2-background, 0 0 0 3px $swal2-outline-color;
 
-@import '~sweetalert2/src/sweetalert2';
+@import 'sweetalert2/src/sweetalert2';
 
-@import '~@fortawesome/fontawesome-free/scss/fontawesome';
-@import '~@fortawesome/fontawesome-free/scss/solid';
-@import '~@fortawesome/fontawesome-free/scss/regular';
-@import '~@fortawesome/fontawesome-free/scss/brands';
+@import '@fortawesome/fontawesome-free/scss/fontawesome';
+@import '@fortawesome/fontawesome-free/scss/solid';
+@import '@fortawesome/fontawesome-free/scss/regular';
+@import '@fortawesome/fontawesome-free/scss/brands';
 
 $hamburger-layer-color      :#FFF;
 $hamburger-hover-opacity    :1;
@@ -63,11 +63,11 @@ $hamburger-layer-height     :0.15rem;
 $hamburger-layer-spacing    :0.2rem;
 $hamburger-padding-y        :1.2rem;
 $hamburger-padding-x        :1.2rem;
-@import '~hamburgers/_sass/hamburgers/hamburgers';
+@import 'hamburgers/_sass/hamburgers/hamburgers';
 
-@import '~trumbowyg/dist/ui/sass/trumbowyg';
+@import 'trumbowyg/dist/ui/sass/trumbowyg';
 
-@import '~protip/css/protip';
+@import 'protip/css/protip';
 
 // Variables
 // @import 'calendar/colors';
@@ -82,8 +82,8 @@ $hamburger-padding-x        :1.2rem;
 @import 'calendar/event_colors-dark';
 
 // select2
-@import '~select2';
-@import '~select2-bootstrap-theme/dist/select2-bootstrap';
+@import 'select2';
+@import 'select2-bootstrap-theme/dist/select2-bootstrap';
 
 body {
     color: $text-gray-200;
@@ -115,7 +115,7 @@ body {
 
 
 // contextmenu
-@import '~jquery-contextmenu/dist/jquery.contextMenu';
+@import 'jquery-contextmenu/dist/jquery.contextMenu';
 // override stupid preset color
 .context-menu-icon.context-menu-icon--fa5 i{
     color: inherit;

--- a/resources/sass/app-tw.css
+++ b/resources/sass/app-tw.css
@@ -2,12 +2,12 @@
 
 /* @import '../../vendor/filament/forms/dist/module.esm.css'; */
 
-@import '~tippy.js/dist/tippy.css';
-@import '~tippy.js/themes/light.css';
+@import 'tippy.js/dist/tippy.css';
+@import 'tippy.js/themes/light.css';
 
-@import '~@fortawesome/fontawesome-free/css/fontawesome.css';
-@import '~@fortawesome/fontawesome-free/css/solid.css';
-@import '~@fortawesome/fontawesome-free/css/brands.css';
+@import '@fortawesome/fontawesome-free/css/fontawesome.css';
+@import '@fortawesome/fontawesome-free/css/solid.css';
+@import '@fortawesome/fontawesome-free/css/brands.css';
 
 @tailwind base;
 @tailwind components;

--- a/resources/sass/calendar/tooltips.scss
+++ b/resources/sass/calendar/tooltips.scss
@@ -1,7 +1,7 @@
 /* ------------------ Weather tooltip Layout ----------------- */
 
-@import '~weather-icons/css/weather-icons.css';
-@import '~weather-icons/css/weather-icons-wind.css';
+@import 'weather-icons/css/weather-icons.css';
+@import 'weather-icons/css/weather-icons-wind.css';
 
 #weather_tooltip_box {
     position: absolute;

--- a/resources/views/calendar/_loadcalendar.blade.php
+++ b/resources/views/calendar/_loadcalendar.blade.php
@@ -17,27 +17,27 @@
     );
 @endif
 
-dark_theme = @json(auth()->user()?->setting('dark_theme') ?? true);
+window.dark_theme = @json(auth()->user()?->setting('dark_theme') ?? true);
 
-hash = `{{ $calendar->hash }}`;
+window.hash = `{{ $calendar->hash }}`;
 
-calendar_name = unescapeHtml("{{ $calendar->name }}");
-calendar_id = {{ $calendar->id }};
-static_data = {!! json_encode($calendar->static_data) !!};
-dynamic_data = {!! json_encode($calendar->dynamic_data) !!};
+window.calendar_name = unescapeHtml("{{ $calendar->name }}");
+window.calendar_id = {{ $calendar->id }};
+window.static_data = {!! json_encode($calendar->static_data) !!};
+window.dynamic_data = {!! json_encode($calendar->dynamic_data) !!};
 
-is_linked = {!! $calendar->isLinked() ? "true" : "null" !!};
-has_parent = {!! $calendar->parent == null ? "null" : "true" !!};
-parent_hash = {!! $calendar->parent != null ? '"'.$calendar->parent->hash.'"' : "null" !!};
-parent_offset = {!! $calendar->parent != null ? $calendar->parent_offset : "null" !!};
+window.is_linked = {!! $calendar->isLinked() ? "true" : "null" !!};
+window.has_parent = {!! $calendar->parent == null ? "null" : "true" !!};
+window.parent_hash = {!! $calendar->parent != null ? '"'.$calendar->parent->hash.'"' : "null" !!};
+window.parent_offset = {!! $calendar->parent != null ? $calendar->parent_offset : "null" !!};
 
-events = {!! json_encode($calendar->events); !!}
-event_categories = {!! json_encode($calendar->event_categories); !!}
+window.events = {!! json_encode($calendar->events); !!}
+window.event_categories = {!! json_encode($calendar->event_categories); !!}
 
-last_static_change = new Date("{{ $calendar->last_static_change }}")
-last_dynamic_change = new Date("{{ $calendar->last_dynamic_change }}")
+window.last_static_change = new Date("{{ $calendar->last_static_change }}")
+window.last_dynamic_change = new Date("{{ $calendar->last_dynamic_change }}")
 
-advancement = {
+window.advancement = {
     advancement_enabled: {{ $calendar->advancement_enabled ? "true" : "false" }},
     advancement_real_rate: {{ $calendar->advancement_real_rate ?? 1 }},
     advancement_real_rate_unit: '{{ $calendar->advancement_real_rate_unit ?? "minutes" }}',

--- a/resources/views/calendar/create.blade.php
+++ b/resources/views/calendar/create.blade.php
@@ -3,7 +3,7 @@
 @push('head')
     <script>
 
-        hash = getUrlParameter('id');
+        window.hash = getUrlParameter('id');
 
         window.Perms = new Perms(
             {{ Auth::check() ? Auth::user()->id : "null" }},
@@ -12,11 +12,11 @@
             'guest'
         );
 
-        preset_applied = false;
-        calendar_name = '';
-        has_parent = false;
-        is_linked = false;
-        static_data = {
+        window.preset_applied = false;
+        window.calendar_name = '';
+        window.has_parent = false;
+        window.is_linked = false;
+        window.static_data = {
             "year_data":{
                 "first_day":1,
                 "overflow":true,
@@ -73,13 +73,13 @@
             }
         };
 
-        events = [];
+        window.events = [];
 
-        event_categories = [];
+        window.event_categories = [];
 
-        randomizer = new RandomCalendar();
+        window.randomizer = new RandomCalendar();
 
-        dynamic_data = {
+        window.dynamic_data = {
             "year": 1,
             "timespan": 0,
             "day": 1,
@@ -88,9 +88,9 @@
             "location": "Equatorial"
         };
 
-        advancement = {}
+        window.advancement = {}
 
-        preview_date = clone(dynamic_data);
+        window.preview_date = clone(window.dynamic_data);
 
         $(document).ready(function(){
 

--- a/resources/views/calendar/edit.blade.php
+++ b/resources/views/calendar/edit.blade.php
@@ -1,13 +1,13 @@
 @extends('templates._calendar')
 
 @push('head')
-    <script>
-    $(document).ready(function(){
+    <script type="module">
+    window.addEventListener("load", function(){
 
         @include('calendar._loadcalendar')
 
-        preview_date = clone(dynamic_data);
-        preview_date.follow = true;
+        window.preview_date = clone(dynamic_data);
+        window.preview_date.follow = true;
 
         rebuild_calendar('calendar', dynamic_data);
 

--- a/resources/views/calendar/guided_embed.blade.php
+++ b/resources/views/calendar/guided_embed.blade.php
@@ -1,5 +1,5 @@
 @push('head')
-    <script src="{{ mix('js/embed.js') }}"></script>
+    @vite('resources/js/embed.js')
     <script>
         function manageEmbed() {
             return {

--- a/resources/views/calendar/view.blade.php
+++ b/resources/views/calendar/view.blade.php
@@ -1,14 +1,14 @@
 @extends('templates._calendar')
 
 @push('head')
-    <script>
+    <script type="module">
 
-    $(document).ready(function(){
+    window.addEventListener("load", function(){
 
         @include('calendar._loadcalendar')
 
-        preview_date = clone(dynamic_data);
-        preview_date.follow = true;
+        window.preview_date = clone(dynamic_data);
+        window.preview_date.follow = true;
 
 
         set_up_view_inputs();
@@ -27,15 +27,15 @@
             do_update_dynamic(hash);
         });
 
-        last_mouse_move = Date.now();
-        poll_timer = setTimeout(check_dates, 5000);
-        instapoll = false;
+        window.last_mouse_move = Date.now();
+        window.poll_timer = setTimeout(check_dates, 5000);
+        window.instapoll = false;
 
         $(window).focus(function(){
             check_dates();
         })
 
-        registered_mousemove_callbacks['view_update'] = function () {
+        window.registered_mousemove_callbacks['view_update'] = function () {
             last_mouse_move = Date.now();
             if (instapoll) {
                 instapoll = false;
@@ -189,7 +189,7 @@
         set_up_view_values();
 
     }
-    if(debounce !== undefined){
+    if(typeof debounce !== 'undefined'){
         var do_update_dynamic = debounce(function(type){
             update_view_dynamic(hash);
         }, 500);

--- a/resources/views/inputs/sidebar/view.blade.php
+++ b/resources/views/inputs/sidebar/view.blade.php
@@ -1,7 +1,7 @@
 @push('head')
-    <script>
+    <script type="module">
 
-    $(document).ready(function(){
+    window.addEventListener("load", function(){
 
         $('#btn_share, .share-body').click(function(){
             var copyText = document.querySelector(".share-body");

--- a/resources/views/pages/embed.blade.php
+++ b/resources/views/pages/embed.blade.php
@@ -2,9 +2,9 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="{{ mix('css/app-tw.css') }}">
+        @vite('resources/css/app-tw.css')
         <meta name="csrf-token" content="{{ csrf_token() }}">
-        <script src="{{ mix('/js/app-tw.js') }}" defer></script>
+        @vite('resources/js/app-tw.js')
 
         <style>
             * {

--- a/resources/views/templates/_head_content.blade.php
+++ b/resources/views/templates/_head_content.blade.php
@@ -36,30 +36,22 @@
         <script>window.bugsnagClient = bugsnag('98440cbeef759631f3d987ab45b26a79')</script>
     @endif
 
-    <script src="{{ mix('/js/app.js') }}"></script>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    @vite('resources/js/app.js')
 
-    <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.17.0/dist/jquery.validate.min.js"></script>
-    <script src="https://rawgit.com/notifyjs/notifyjs/master/dist/notify.js"></script>
+    {{-- <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css"> --}}
+    {{-- <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script> --}}
+
+    {{-- <script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.17.0/dist/jquery.validate.min.js"></script> --}}
+    {{-- <script src="https://rawgit.com/notifyjs/notifyjs/master/dist/notify.js"></script> --}}
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
 
-    {{-- <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.js"></script> --}}
-
-    <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.css" />
-    <script src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.js"></script>
-
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.min.css">
 
-    {{-- <link --}}
-    {{--     rel="stylesheet" --}}
-    {{--     href="https://unpkg.com/simplebar@latest/dist/simplebar.css" --}}
-    {{-- /> --}}
-    {{-- <script src="https://unpkg.com/simplebar@latest/dist/simplebar.min.js"></script> --}}
 
-    <script>
+    <script type="module">
 
     window.baseurl = '{{ getenv('WEBADDRESS') }}';
     window.apiurl = '{{ getenv('WEBADDRESS') }}'+'api/v1';
@@ -83,42 +75,42 @@
         return screenType;
     }
 
-    $.ajaxSetup({
-        headers: {
-            'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content'),
-            'Authorization': 'Bearer '+$('meta[name="api-token"]').attr('content')
-        },
-        data: {
-            api_token: $('meta[name="api-token"]').attr('content')
-        }
-    });
 
-    $(document).ajaxError(function(event, jqxhr, settings, thrownError) {
-        if(jqxhr.status === 422) {
-            return;
-        }
-
-        if(jqxhr.status === 503) {
-            if(jqxhr.responseJSON.message.length > 0) {
-                $.notify("Fantasy Calendar is in maintenance mode. Please try again later.\nReason: " + jqxhr.responseJSON.message);
-            } else {
-                $.notify("Fantasy Calendar is in maintenance mode. Please try that again later.");
+    window.addEventListener("load", function(){
+        $.ajaxSetup({
+            headers: {
+                'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content'),
+                'Authorization': 'Bearer '+$('meta[name="api-token"]').attr('content')
+            },
+            data: {
+                api_token: $('meta[name="api-token"]').attr('content')
             }
-            return;
-        }
+        });
 
-        if(jqxhr.responseJSON.message.length > 0) {
-            $.notify("Error: " + jqxhr.responseJSON.message);
-        } else {
-            $.notify(thrownError + " (F12 to see more detail)");
-        }
-    });
+        $(document).ajaxError(function(event, jqxhr, settings, thrownError) {
+            if(jqxhr.status === 422) {
+                return;
+            }
 
-    $(document).ready(function(){
+            if(jqxhr.status === 503) {
+                if(jqxhr.responseJSON.message.length > 0) {
+                    $.notify("Fantasy Calendar is in maintenance mode. Please try again later.\nReason: " + jqxhr.responseJSON.message);
+                } else {
+                    $.notify("Fantasy Calendar is in maintenance mode. Please try that again later.");
+                }
+                return;
+            }
 
-        window.onerror = function(error, url, line) {
+            if(jqxhr.responseJSON.message.length > 0) {
+                $.notify("Error: " + jqxhr.responseJSON.message);
+            } else {
+                $.notify(thrownError + " (F12 to see more detail)");
+            }
+        });
+
+        window.addEventListener("error",  function(error, url, line) {
             $.notify("Error:\n "+error+" \nin file "+url+" \non line "+line);
-        }
+        });
 
         $.protip({
             defaults: {
@@ -134,7 +126,7 @@
         var cookiedomain = window.location.hostname.split('.')[window.location.hostname.split('.').length-2]+'.'+window.location.hostname.split('.')[window.location.hostname.split('.').length-1];
         document.cookie = 'fantasycalendar_remember=; Max-Age=0; path=/; domain=' + cookiedomain;
 
-        $.trumbowyg.svgPath = '/images/icons.svg';
+        {{-- $.trumbowyg.svgPath = '/images/icons.svg'; --}}
 
         if (window.localStorage.getItem('inputs_collapsed') != null) {
             toggle_sidebar(window.localStorage.getItem('inputs_collapsed') == 'true');
@@ -161,29 +153,29 @@
 
     </script>
 
-    <script src="{{ asset("/js/vendor/sortable/jquery-sortable-min.js") }}"></script>
-    <script src="{{ asset("/js/vendor/spectrum/spectrum.js") }}"></script>
-    <script src="{{ asset("/js/vendor/alpine/cdn.js") }}" defer></script>
-    <script src="{{ asset("/js/vendor/simplebar/simplebar.min.js") }}" defer></script>
+    {{-- @vite("js/vendor/sortable/jquery-sortable-min.js") --}}
+    {{-- @vite("js/vendor/spectrum/spectrum.js") --}}
+    {{-- @vite("js/vendor/alpine/cdn.js") --}}
+    {{-- @vite("js/vendor/simplebar/simplebar.min.js") --}}
 
-    <script src="{{ mix('js/calendar/header.js') }}"></script>
-    <script src="{{ mix('js/calendar/calendar_ajax_functions.js') }}"></script>
-    <script src="{{ mix('js/calendar/calendar_functions.js') }}"></script>
-    <script src="{{ mix('js/calendar/calendar_variables.js') }}"></script>
-    <script src="{{ mix('js/calendar/calendar_weather_layout.js') }}"></script>
-    <script src="{{ mix('js/calendar/calendar_day_data_layout.js') }}"></script>
-    <script src="{{ mix('js/calendar/calendar_season_generator.js') }}"></script>
-    <script src="{{ mix('js/calendar/calendar_inputs_visitor.js') }}"></script>
-    <script src="{{ mix('js/calendar/calendar_inputs_view.js') }}"></script>
-    <script src="{{ mix('js/calendar/calendar_inputs_edit.js') }}"></script>
-    <script src="{{ mix('js/calendar/calendar_manager.js') }}"></script>
-    <script src="{{ mix('js/calendar/calendar_presets.js') }}"></script>
-    <script src="{{ mix('js/calendar/calendar_workers.js') }}"></script>
+    {{-- @vite('js/calendar/header.js') --}}
+    {{-- @vite('js/calendar/calendar_ajax_functions.js') --}}
+    {{-- @vite('js/calendar/calendar_functions.js') --}}
+    {{-- @vite('js/calendar/calendar_variables.js') --}}
+    {{-- @vite('js/calendar/calendar_weather_layout.js') --}}
+    {{-- @vite('js/calendar/calendar_day_data_layout.js') --}}
+    {{-- @vite('js/calendar/calendar_season_generator.js') --}}
+    {{-- @vite('js/calendar/calendar_inputs_visitor.js') --}}
+    {{-- @vite('js/calendar/calendar_inputs_view.js') --}}
+    {{-- @vite('js/calendar/calendar_inputs_edit.js') --}}
+    {{-- @vite('js/calendar/calendar_manager.js') --}}
+    {{-- @vite('js/calendar/calendar_presets.js') --}}
+    {{-- @vite('js/calendar/calendar_workers.js') --}}
 
     @if(!Auth::check() || Auth::user()->setting('dark_theme'))
-        <link rel="stylesheet" href="{{ mix('css/app-dark.css') }}">
+        @vite('resources/sass/app-dark.scss')
     @else
-        <link rel="stylesheet" href="{{ mix('css/app.css') }}">
+        @vite('resources/sass/app.scss')
     @endif
     <link rel="stylesheet" href="{{ asset("/js/vendor/spectrum/spectrum.css") }}">
     <link rel="stylesheet" href="{{ asset("/js/vendor/simplebar/simplebar.css") }}">

--- a/resources/views/templates/_head_content_tw.blade.php
+++ b/resources/views/templates/_head_content_tw.blade.php
@@ -46,7 +46,7 @@
         <script>window.bugsnagClient = bugsnag('98440cbeef759631f3d987ab45b26a79')</script>
     @endif
 
-    <script src="{{ mix('/js/app-tw.js') }}" defer></script>
+    @vite('resources/js/app-tw.js')
     @feature('stripe')
         <script src="https://js.stripe.com/v3/"></script>
     @endfeature
@@ -77,7 +77,7 @@
 
     </script>
 
-    <link rel="stylesheet" href="{{ mix('css/app-tw.css') }}">
+    @vite('resources/sass/app-tw.css')
 
     @stack('head')
 </head>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
-const colors = require('tailwindcss/colors')
+import colors from 'tailwindcss/colors';
 
-module.exports = {
+export default {
     darkMode: 'class',
     content: [
         "./resources/**/*.blade.php",
@@ -9,20 +9,6 @@ module.exports = {
         "./resources/**/*.vue",
         "./app/View/Components/**/*.php",
         './vendor/filament/**/*.blade.php',
-    ],
-    safelist: [
-        // {
-        //     pattern: /bg-(.*)-(50|100|200|300|400|500|600|700|800|900)/,
-        //     variants: ['hover', 'dark', 'dark:hover'],
-        // },
-        // {
-        //     pattern: /text-(.*)-(50|100|200|300|400|500|600|700|800|900)/,
-        //     variants: ['hover', 'dark', 'dark:hover'],
-        // },
-        // {
-        //     pattern: /border-(.*)-(50|100|200|300|400|500|600|700|800|900)/,
-        //     variants: ['hover', 'dark', 'dark:hover'],
-        // },
     ],
     theme: {
         extend: {
@@ -49,8 +35,8 @@ module.exports = {
         }
     },
     plugins: [
-        require('@tailwindcss/forms'),
-        require('@tailwindcss/typography'),
-        require('@tailwindcss/aspect-ratio'),
+        '@tailwindcss/forms',
+        '@tailwindcss/typography',
+        '@tailwindcss/aspect-ratio',
     ],
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,87 @@
+import vuePlugin from "@vitejs/plugin-vue";
+import laravel from "laravel-vite-plugin";
+import { defineConfig } from "vite";
+import fs from 'fs';
+import { nodePolyfills } from 'vite-plugin-node-polyfills';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
+import inject from "@rollup/plugin-inject";
+
+let server = {
+    host: '0.0.0.0',
+    hmr: {
+        host: 'fantasy-calendar.test'
+    }
+};
+
+if (fs.existsSync('/home/axel/.valet/Certificates/fantasy-calendar.test.key')) {
+    server.https = {
+        key: fs.readFileSync('/home/axel/.valet/Certificates/fantasy-calendar.test.key'),
+        cert: fs.readFileSync('/home/axel/.valet/Certificates/fantasy-calendar.test.crt'),
+    };
+}
+
+
+export default defineConfig({
+    server,
+    plugins: [
+        inject({
+          include: '',
+          $: 'jquery',
+          jQuery: 'jquery',
+        }),
+        viteStaticCopy({
+            targets: [
+                {
+                    src: 'resources/js/**/*.js',
+                    dest: 'js',
+                },
+                {
+                    src: 'node_modules/trumbowyg/dist/ui/icons.svg',
+                    dest: 'public/images'
+                },
+                {
+                    src: 'node_modules/alpinejs/dist/cdn.js',
+                    dest: 'public/js/vendor/alpine'
+                },
+                {
+                    src: 'node_modules/simplebar/dist/simplebar.min.js',
+                    dest: 'public/js/vendor/simplebar'
+                },
+                {
+                    src: 'node_modules/simplebar/dist/simplebar.css',
+                    dest: 'public/js/vendor/simplebar'
+                },
+                {
+                    src: 'resources/webfonts/**/*',
+                    dest: 'public/resources/webfonts'
+                }
+            ]
+        }),
+        laravel([
+            "resources/js/app.js",
+            "resources/js/app-tw.js",
+            "resources/sass/app-tw.css",
+            "resources/sass/app.scss",
+            "resources/sass/app-dark.scss",
+        ]),
+        vuePlugin({
+            template: {
+                transformAssetUrls: {
+                    // The Vue plugin will re-write asset URLs, when referenced
+                    // in Single File Components, to point to the Laravel web
+                    // server. Setting this to `null` allows the Laravel plugin
+                    // to instead re-write asset URLs to point to the Vite
+                    // server instead.
+                    base: null,
+
+                    // The Vue plugin will parse absolute URLs and treat them
+                    // as absolute paths to files on disk. Setting this to
+                    // `false` will leave absolute URLs un-touched so they can
+                    // reference assets in the public directory as expected.
+                    includeAbsolute: false,
+                },
+            },
+        }),
+        nodePolyfills(),
+    ],
+});

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -11,27 +11,6 @@ const mix = require('laravel-mix');
  |
  */
 
-if(process.env.BROWSERSYNC === 'true') {
-    mix.browserSync({
-        injectChanges: true,
-        proxy: 'php:8000',
-        port: 9980,
-        open: false,
-        reloadDebounce: 200,
-        files: [
-            "public/mix-manifest.json"
-        ],
-        snippetOptions: {
-            rule: {
-                match: /<\/body>/i,
-                fn: function(snippet, match) {
-                    return snippet + match;
-                }
-            }
-        }
-    });
-}
-
 // Copy components and vendor scripts
 mix.copyDirectory('resources/js/components', 'public/js/components');
 mix.copyDirectory('resources/js/vendor', 'public/js/vendor');


### PR DESCRIPTION
We would like to migrate to Vite from Mix, though there are _quite_ a few challenges along the way.

As of writing, I've already solved some of the basics. However, FC relies very heavily on a lot of globals and somewhat out of date(read: Non-ESM) vendor libraries.

What that basically means for us is that Vite _may not_ be able to work. This branch could involve some replacement of components (Such as moving away from notify.js, or replacing trumbowyg with something else)...

It's also entirely possible that migration simply isn't a possibility for the state of FC today. If that's the case, then we'll abandon this PR/branch and move on to a full-scale rewrite instead =]
