### PR TITLE
Auto Advancement Default Raw JSON Webhook Selection Fix

### DIFF
--- a/app/Services/Webhooks/Webhook.php
+++ b/app/Services/Webhooks/Webhook.php
@@ -20,7 +20,7 @@ class Webhook
         /**
          * @var Handler $handler
          */
-        $handler = Arr::get(static::$webhookHandlers, $type, 'raw_json');
+        $handler = Arr::get(static::$webhookHandlers, $type, static::$webhookHandlers['raw_json']);
 
         return $handler::make($url, $calendar);
     }


### PR DESCRIPTION
This PR addresses an issue where enabling real-time advancement and then setting a URL for a raw JSON webhook breaks the webhook job.

It breaks because the calendar's `advancement_webhook_format` remains null, and the webhook job tries to call `make` on a nonexistent class.
